### PR TITLE
Add parallel requests support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
     - if [[ "$TRAVIS_PHP_VERSION" != "5.3" && "$TRAVIS_PHP_VERSION" != hhvm* ]]; then php-cgi -b 127.0.0.1:9000 & fi
     - if [[ "$TRAVIS_PHP_VERSION" = hhvm* ]]; then hhvm --mode server -vServer.Type=fastcgi -vServer.Port=9000 -vServer.FixPathInfo=true & fi
     - composer self-update
-    - composer require --no-update symfony/event-dispatcher:${SYMFONY_VERSION}
+    - composer require symfony/event-dispatcher:${SYMFONY_VERSION} --no-update --dev
     - if [[ "$TRAVIS_PHP_VERSION" = 5.3* ]]; then composer remove guzzlehttp/guzzle --dev --no-update; fi
     - if [[ "$TRAVIS_PHP_VERSION" = 5.3* ]]; then composer remove guzzlehttp/streams --dev --no-update; fi
     - if [[ "$TRAVIS_PHP_VERSION" = 5.3* ]]; then composer remove react/http-client --dev --no-update; fi

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -79,4 +79,57 @@ $response = $httpAdapter->sendRequest(new InternalRequest($url, $method));
 
 If you want to learn more about the `Ivory\HttpAdapter\Message\Request`, your can read this [doc](/doc/request.md) or
 if you want to learn more about the `Ivory\HttpAdapter\Message\InternalRequest`, your can read this
-[doc](/doc/internal_request.md)..
+[doc](/doc/internal_request.md).
+
+## Send multiple requests
+
+``` php
+use Ivory\HttpAdapter\Message\InternalRequest;
+use Ivory\HttpAdapter\Message\Request;
+use Ivory\HttpAdapter\MultiHttpAdapterException;
+
+$requests = array(
+    // An url (GET 1.1)
+    'http://egeloen.fr',
+
+    // An array representing the parameters of the `MessageFactoryInterface::createInternalRequest`
+    array('http://egeloen.fr', 'GET', 1.1, array('Content-Type' => 'json', '{"foo":"bar"}')),
+
+    // A PSR-7 request
+    new Request('http://egeloen.fr', 'GET'),
+
+    // An internal request
+    new InternalRequest('http://egeloen.fr', 'GET'),
+);
+
+try {
+    $responses = $httpAdapter->sendRequests($requests);
+} catch (MultiHttpAdapterException $e) {
+    $responses = $e->getResponses();
+    $exceptions = $e->getExceptions();
+}
+```
+
+You can additionaly pass two callables which will be triggered as soon as a request is completed:
+
+``` php
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Ivory\HttpAdapter\MultiHttpAdapterException;
+
+$success = function (ResponseInterface $response) {
+    $request = response->getParameter('request');
+};
+
+$error = function (HttpAdapterException $exception) {
+    $request = $exception->getRequest();
+
+    if ($exception->hasResponse()) {
+        $response = $exception->getResponse();
+    }
+};
+
+$responses = $httpAdapter->sendRequests($requests, $success, $error);
+```
+
+The method will not throw an exception if you pass the `error` callable.

--- a/src/Event/Events.php
+++ b/src/Event/Events.php
@@ -28,4 +28,13 @@ class Events extends AbstractUninstantiableAsset
 
     /** @const string The exception event. */
     const EXCEPTION = 'ivory.http_adapter.exception';
+
+    /** @const string The pre send event. */
+    const MULTI_PRE_SEND = 'ivory.http_adapter.multi_pre_send';
+
+    /** @const string The post send event. */
+    const MULTI_POST_SEND = 'ivory.http_adapter.multi_post_send';
+
+    /** @const string The exception event. */
+    const MULTI_EXCEPTION = 'ivory.http_adapter.multi_exception';
 }

--- a/src/Event/MultiExceptionEvent.php
+++ b/src/Event/MultiExceptionEvent.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event;
+
+use Ivory\HttpAdapter\HttpAdapterInterface;
+use Ivory\HttpAdapter\MultiHttpAdapterException;
+
+/**
+ * Multi exception event.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiExceptionEvent extends AbstractEvent
+{
+    /** @var \Ivory\HttpAdapter\MultiHttpAdapterException */
+    private $exception;
+
+    /**
+     * Creates an exception event.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface      $httpAdapter The http adapter.
+     * @param \Ivory\HttpAdapter\MultiHttpAdapterException $exception   The exception.
+     */
+    public function __construct(HttpAdapterInterface $httpAdapter, MultiHttpAdapterException $exception)
+    {
+        parent::__construct($httpAdapter);
+
+        $this->setException($exception);
+    }
+
+    /**
+     * Gets the exception.
+     *
+     * @return \Ivory\HttpAdapter\MultiHttpAdapterException The exception.
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+
+    /**
+     * Sets the exception.
+     *
+     * @param \Ivory\HttpAdapter\MultiHttpAdapterException $exception The exception.
+     */
+    public function setException(MultiHttpAdapterException $exception)
+    {
+        $this->exception = $exception;
+    }
+}

--- a/src/Event/MultiPostSendEvent.php
+++ b/src/Event/MultiPostSendEvent.php
@@ -1,0 +1,235 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event;
+
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\HttpAdapterInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+/**
+ * Multi post send event.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiPostSendEvent extends AbstractEvent
+{
+    /** @var array */
+    private $responses;
+
+    /** @var array */
+    private $exceptions = array();
+
+    /**
+     * Creates a multi post send event.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface $httpAdapter The http adapter.
+     * @param array                                   $responses   The responses.
+     */
+    public function __construct(HttpAdapterInterface $httpAdapter, array $responses)
+    {
+        parent::__construct($httpAdapter);
+
+        $this->setResponses($responses);
+    }
+
+    /**
+     * Clears the responses.
+     */
+    public function clearResponses()
+    {
+        $this->responses = array();
+    }
+
+    /**
+     * Checks if there are responses.
+     *
+     * @return boolean TRUE if there are responses else FALSE.
+     */
+    public function hasResponses()
+    {
+        return !empty($this->responses);
+    }
+
+    /**
+     * Gets the responses.
+     *
+     * @return array The responses.
+     */
+    public function getResponses()
+    {
+        return $this->responses;
+    }
+
+    /**
+     * Sets the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function setResponses(array $responses)
+    {
+        $this->clearResponses();
+        $this->addResponses($responses);
+    }
+
+    /**
+     * Adds the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function addResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->addResponse($response);
+        }
+    }
+
+    /**
+     * Removes the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function removeResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->removeResponse($response);
+        }
+    }
+
+    /**
+     * Checks if there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     *
+     * @return boolean TRUE if there is the response else FALSE.
+     */
+    public function hasResponse(ResponseInterface $response)
+    {
+        return array_search($response, $this->responses, true) !== false;
+    }
+
+    /**
+     * Adds a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function addResponse(ResponseInterface $response)
+    {
+        $this->responses[] = $response;
+    }
+
+    /**
+     * Removes a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function removeResponse(ResponseInterface $response)
+    {
+        unset($this->responses[array_search($response, $this->responses, true)]);
+        $this->responses = array_values($this->responses);
+    }
+
+    /**
+     * Clears the exceptions.
+     */
+    public function clearExceptions()
+    {
+        $this->exceptions = array();
+    }
+
+    /**
+     * Checks if there are exceptions.
+     *
+     * @return boolean TRUE if there are exceptions else FALSE.
+     */
+    public function hasExceptions()
+    {
+        return !empty($this->exceptions);
+    }
+
+    /**
+     * Gets the exceptions.
+     *
+     * @return array The exceptions.
+     */
+    public function getExceptions()
+    {
+        return $this->exceptions;
+    }
+
+    /**
+     * Sets the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function setExceptions(array $exceptions)
+    {
+        $this->clearExceptions();
+        $this->addExceptions($exceptions);
+    }
+
+    /**
+     * Adds the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function addExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->addException($exception);
+        }
+    }
+
+    /**
+     * Removes the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function removeExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->removeException($exception);
+        }
+    }
+
+    /**
+     * Checks if there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     *
+     * @return boolean TRUE if there is the exception else FALSE.
+     */
+    public function hasException(HttpAdapterException $exception)
+    {
+        return array_search($exception, $this->exceptions, true) !== false;
+    }
+
+    /**
+     * Adds an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception
+     */
+    public function addException(HttpAdapterException $exception)
+    {
+        $this->exceptions[] = $exception;
+    }
+
+    /**
+     * Removes an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    public function removeException(HttpAdapterException $exception)
+    {
+        unset($this->exceptions[array_search($exception, $this->exceptions, true)]);
+        $this->exceptions = array_values($this->exceptions);
+    }
+}

--- a/src/Event/MultiPreSendEvent.php
+++ b/src/Event/MultiPreSendEvent.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event;
+
+use Ivory\HttpAdapter\HttpAdapterInterface;
+use Ivory\HttpAdapter\Message\InternalRequestInterface;
+
+/**
+ * Multi pre send event.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiPreSendEvent extends AbstractEvent
+{
+    /** @var array */
+    private $requests;
+
+    /**
+     * Creates a multi pre send event.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface $httpAdapter The http adapter.
+     * @param array                                   $requests    The requests.
+     */
+    public function __construct(HttpAdapterInterface $httpAdapter, array $requests)
+    {
+        parent::__construct($httpAdapter);
+
+        $this->setRequests($requests);
+    }
+
+    /**
+     * Clears the requests.
+     */
+    public function clearRequests()
+    {
+        $this->requests = array();
+    }
+
+    /**
+     * Checks if there are requests.
+     *
+     * @return boolean TRUE if there are requests else FALSE.
+     */
+    public function hasRequests()
+    {
+        return !empty($this->requests);
+    }
+
+    /**
+     * Gets the requests.
+     *
+     * @return array The requests.
+     */
+    public function getRequests()
+    {
+        return $this->requests;
+    }
+
+    /**
+     * Sets the requests.
+     *
+     * @param array $requests The requests.
+     */
+    public function setRequests(array $requests)
+    {
+        $this->clearRequests();
+        $this->addRequests($requests);
+    }
+
+    /**
+     * Adds the requests.
+     *
+     * @param array $requests The requests.
+     */
+    public function addRequests(array $requests)
+    {
+        foreach ($requests as $request) {
+            $this->addRequest($request);
+        }
+    }
+
+    /**
+     * Removes the requests.
+     *
+     * @param array $requests The requests.
+     */
+    public function removeRequests(array $requests)
+    {
+        foreach ($requests as $request) {
+            $this->removeRequest($request);
+        }
+    }
+
+    /**
+     * Checks if there is a request.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $request The request.
+     *
+     * @return boolean TRUE if there is the request else FALSE.
+     */
+    public function hasRequest(InternalRequestInterface $request)
+    {
+        return array_search($request, $this->requests, true) !== false;
+    }
+
+    /**
+     * Adds a request.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $request The request.
+     */
+    public function addRequest(InternalRequestInterface $request)
+    {
+        $this->requests[] = $request;
+    }
+
+    /**
+     * Removes a request.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $request The request.
+     */
+    public function removeRequest(InternalRequestInterface $request)
+    {
+        unset($this->requests[array_search($request, $this->requests, true)]);
+        $this->requests = array_values($this->requests);
+    }
+}

--- a/src/Event/Retry/Retry.php
+++ b/src/Event/Retry/Retry.php
@@ -27,7 +27,7 @@ class Retry implements RetryInterface
     private $strategy;
 
     /**
-     * Creates a retry subscriber.
+     * Creates a retry.
      *
      * @param \Ivory\HttpAdapter\Event\Retry\Strategy\RetryStrategyInterface|null $strategy The strategy.
      */
@@ -55,7 +55,7 @@ class Retry implements RetryInterface
     /**
      * {@inheritdoc}
      */
-    public function retry(InternalRequestInterface $internalRequest)
+    public function retry(InternalRequestInterface $internalRequest, $wait = true)
     {
         if (!$this->strategy->verify($internalRequest)) {
             $internalRequest->setParameter(
@@ -66,7 +66,7 @@ class Retry implements RetryInterface
             return false;
         }
 
-        if (($delay = $this->strategy->delay($internalRequest)) > 0) {
+        if ($wait && ($delay = $this->strategy->delay($internalRequest)) > 0) {
             usleep($delay * 1000000);
         }
 

--- a/src/Event/Retry/RetryInterface.php
+++ b/src/Event/Retry/RetryInterface.php
@@ -42,8 +42,9 @@ interface RetryInterface
      * Checks if it should retry a request.
      *
      * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $internalRequest The internal request.
+     * @param boolean                                             $wait            TRUE if the delay should be considered else FALSE.
      *
      * @return boolean TRUE if should retry the request else FALSE.
      */
-    public function retry(InternalRequestInterface $internalRequest);
+    public function retry(InternalRequestInterface $internalRequest, $wait = true);
 }

--- a/src/Event/Subscriber/BasicAuthSubscriber.php
+++ b/src/Event/Subscriber/BasicAuthSubscriber.php
@@ -13,6 +13,7 @@ namespace Ivory\HttpAdapter\Event\Subscriber;
 
 use Ivory\HttpAdapter\Event\BasicAuth\BasicAuthInterface;
 use Ivory\HttpAdapter\Event\Events;
+use Ivory\HttpAdapter\Event\MultiPreSendEvent;
 use Ivory\HttpAdapter\Event\PreSendEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
@@ -67,10 +68,25 @@ class BasicAuthSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * On multi pre send event.
+     *
+     * @param \Ivory\HttpAdapter\Event\MultiPreSendEvent $event The multi pre send event.
+     */
+    public function onMultiPreSend(MultiPreSendEvent $event)
+    {
+        foreach ($event->getRequests() as $request) {
+            $this->basicAuth->authenticate($request);
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function getSubscribedEvents()
     {
-        return array(Events::PRE_SEND => array('onPreSend', 300));
+        return array(
+            Events::PRE_SEND       => array('onPreSend', 300),
+            Events::MULTI_PRE_SEND => array('onMultiPreSend', 300),
+        );
     }
 }

--- a/src/Event/Subscriber/StopwatchSubscriber.php
+++ b/src/Event/Subscriber/StopwatchSubscriber.php
@@ -13,6 +13,9 @@ namespace Ivory\HttpAdapter\Event\Subscriber;
 
 use Ivory\HttpAdapter\Event\Events;
 use Ivory\HttpAdapter\Event\ExceptionEvent;
+use Ivory\HttpAdapter\Event\MultiExceptionEvent;
+use Ivory\HttpAdapter\Event\MultiPostSendEvent;
+use Ivory\HttpAdapter\Event\MultiPreSendEvent;
 use Ivory\HttpAdapter\Event\PreSendEvent;
 use Ivory\HttpAdapter\Event\PostSendEvent;
 use Ivory\HttpAdapter\HttpAdapterInterface;
@@ -91,14 +94,63 @@ class StopwatchSubscriber implements EventSubscriberInterface
     }
 
     /**
+     * On multi pre send event.
+     *
+     * @param \Ivory\HttpAdapter\Event\MultiPreSendEvent $event The multi pre send event.
+     */
+    public function onMultiPreSend(MultiPreSendEvent $event)
+    {
+        foreach ($event->getRequests() as $request) {
+            $this->stopwatch->start($this->getStopwatchName($event->getHttpAdapter(), $request));
+        }
+    }
+
+    /**
+     * On multi post send event.
+     *
+     * @param \Ivory\HttpAdapter\Event\MultiPostSendEvent $event The multi post send event.
+     */
+    public function onMultiPostSend(MultiPostSendEvent $event)
+    {
+        foreach ($event->getResponses() as $response) {
+            $this->stopwatch->stop(
+                $this->getStopwatchName($event->getHttpAdapter(), $response->getParameter('request'))
+            );
+        }
+    }
+
+    /**
+     * On multi exception event.
+     *
+     * @param \Ivory\HttpAdapter\Event\MultiExceptionEvent $event The multi exception event.
+     */
+    public function onMultiException(MultiExceptionEvent $event)
+    {
+        foreach ($event->getException()->getResponses() as $response) {
+            $this->stopwatch->stop(
+                $this->getStopwatchName($event->getHttpAdapter(), $response->getParameter('request'))
+            );
+        }
+
+        foreach ($event->getException()->getExceptions() as $exception) {
+            $this->stopwatch->stop(
+                $this->getStopwatchName($event->getHttpAdapter(), $exception->getRequest())
+            );
+        }
+    }
+
+    /**
      * {@inheritdoc}
      */
     public static function getSubscribedEvents()
     {
         return array(
-            Events::PRE_SEND  => array('onPreSend', 10000),
-            Events::POST_SEND => array('onPostSend', 10000),
-            Events::EXCEPTION => array('onException', 10000),
+            Events::PRE_SEND        => array('onPreSend', 10000),
+            Events::POST_SEND       => array('onPostSend', 10000),
+            Events::EXCEPTION       => array('onException', 10000),
+            Events::MULTI_PRE_SEND  => array('onMultiPreSend', 10000),
+            Events::MULTI_POST_SEND => array('onMultiPostSend', 10000),
+            Events::MULTI_EXCEPTION => array('onMultiException', 10000),
         );
     }
 

--- a/src/HttpAdapterException.php
+++ b/src/HttpAdapterException.php
@@ -225,6 +225,21 @@ class HttpAdapterException extends \Exception
     }
 
     /**
+     * Gets the "REQUEST IS NOT VALID" exception.
+     *
+     * @param mixed $request The request.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException The "REQUEST IS NOT VALID" exception.
+     */
+    public static function requestIsNotValid($request)
+    {
+        return new self(sprintf(
+            'The request must be a string, an array or implement "Psr\Http\Message\OutgoingRequestInterface" ("%s" given).',
+            is_object($request) ? get_class($request) : gettype($request)
+        ));
+    }
+
+    /**
      * Gets the "STREAM IS NOT VALID" exception.
      *
      * @param mixed  $stream   The stream.

--- a/src/HttpAdapterInterface.php
+++ b/src/HttpAdapterInterface.php
@@ -176,6 +176,19 @@ interface HttpAdapterInterface
     public function sendRequest(OutgoingRequestInterface $request);
 
     /**
+     * Sends requests.
+     *
+     * @param array         $requests The requests.
+     * @param callable|null $success  The success callable.
+     * @param callable|null $error    The error callable.
+     *
+     * @throws \Ivory\HttpAdapter\MultiHttpAdapterException If an error occured when you don't provide the error callable.
+     *
+     * @return array $responses The responses.
+     */
+    public function sendRequests(array $requests, $success = null, $error = null);
+
+    /**
      * Gets the name.
      *
      * @return string The name.

--- a/src/MultiHttpAdapterException.php
+++ b/src/MultiHttpAdapterException.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter;
+
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+/**
+ * Multi http adapter exception.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiHttpAdapterException extends \Exception
+{
+    /** @var array */
+    private $exceptions;
+
+    /** @var array */
+    private $responses;
+
+    /**
+     * Creates a multi http adapter exception.
+     *
+     * @param array $exceptions The exceptions.
+     * @param array $responses  The responses.
+     */
+    public function __construct(array $exceptions = array(), array $responses = array())
+    {
+        parent::__construct('An error occured when sending multiple requests.');
+
+        $this->setExceptions($exceptions);
+        $this->setResponses($responses);
+    }
+
+    /**
+     * Clears the exceptions.
+     */
+    public function clearExceptions()
+    {
+        $this->exceptions = array();
+    }
+
+    /**
+     * Checks if there are exceptions.
+     *
+     * @return boolean TRUE if there are exceptions else FALSE.
+     */
+    public function hasExceptions()
+    {
+        return !empty($this->exceptions);
+    }
+
+    /**
+     * Gets the exceptions.
+     *
+     * @return array The exceptions.
+     */
+    public function getExceptions()
+    {
+        return $this->exceptions;
+    }
+
+    /**
+     * Sets the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function setExceptions(array $exceptions)
+    {
+        $this->clearExceptions();
+        $this->addExceptions($exceptions);
+    }
+
+    /**
+     * Adds the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function addExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->addException($exception);
+        }
+    }
+
+    /**
+     * Removes the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function removeExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->removeException($exception);
+        }
+    }
+
+    /**
+     * Checks if there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     *
+     * @return boolean TRUE if there is the exception else FALSE.
+     */
+    public function hasException(HttpAdapterException $exception)
+    {
+        return array_search($exception, $this->exceptions, true) !== false;
+    }
+
+    /**
+     * Adds an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    public function addException(HttpAdapterException $exception)
+    {
+        $this->exceptions[] = $exception;
+    }
+
+    /**
+     * Removes an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    public function removeException(HttpAdapterException $exception)
+    {
+        unset($this->exceptions[array_search($exception, $this->exceptions, true)]);
+        $this->exceptions = array_values($this->exceptions);
+    }
+
+    /**
+     * Clears the responses.
+     */
+    public function clearResponses()
+    {
+        $this->responses = array();
+    }
+
+    /**
+     * Checks if there are exceptions.
+     *
+     * @return boolean TRUE if there are exceptions else FALSE.
+     */
+    public function hasResponses()
+    {
+        return !empty($this->responses);
+    }
+
+    /**
+     * Gets the responses.
+     *
+     * @return array The responses.
+     */
+    public function getResponses()
+    {
+        return $this->responses;
+    }
+
+    /**
+     * Sets the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function setResponses(array $responses)
+    {
+        $this->clearResponses();
+        $this->addResponses($responses);
+    }
+
+    /**
+     * Adds the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function addResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->addResponse($response);
+        }
+    }
+
+    /**
+     * Removes the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function removeResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->removeResponse($response);
+        }
+    }
+
+    /**
+     * Checks if there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     *
+     * @return boolean TRUE if there is the response else FALSE.
+     */
+    public function hasResponse(ResponseInterface $response)
+    {
+        return array_search($response, $this->responses, true) !== false;
+    }
+
+    /**
+     * Adds a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function addResponse(ResponseInterface $response)
+    {
+        $this->responses[] = $response;
+    }
+
+    /**
+     * Removes a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function removeResponse(ResponseInterface $response)
+    {
+        unset($this->responses[array_search($response, $this->responses, true)]);
+        $this->responses = array_values($this->responses);
+    }
+}

--- a/src/StopwatchHttpAdapter.php
+++ b/src/StopwatchHttpAdapter.php
@@ -114,6 +114,14 @@ class StopwatchHttpAdapter extends AbstractHttpAdapterTemplate
     /**
      * {@inheritdoc}
      */
+    public function sendRequests(array $requests, $success = null, $error = null)
+    {
+        return $this->watch('sendRequests', array($requests, $success, $error));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return $this->httpAdapter->getName();
@@ -125,7 +133,7 @@ class StopwatchHttpAdapter extends AbstractHttpAdapterTemplate
      * @param string $method The method.
      * @param array  $params The parameters.
      *
-     * @return \Ivory\HttpAdapter\Message\ResponseInterface The response.
+     * @return mixed The result.
      */
     private function watch($method, array $params = array())
     {
@@ -134,7 +142,7 @@ class StopwatchHttpAdapter extends AbstractHttpAdapterTemplate
         $this->stopwatch->start($name);
 
         try {
-            $response = call_user_func_array(array($this->httpAdapter, $method), $params);
+            $result = call_user_func_array(array($this->httpAdapter, $method), $params);
         } catch (\Exception $e) {
             $this->stopwatch->stop($name);
 
@@ -143,6 +151,6 @@ class StopwatchHttpAdapter extends AbstractHttpAdapterTemplate
 
         $this->stopwatch->stop($name);
 
-        return $response;
+        return $result;
     }
 }

--- a/tests/Event/MultiExceptionEventTest.php
+++ b/tests/Event/MultiExceptionEventTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event;
+
+use Ivory\HttpAdapter\Event\MultiExceptionEvent;
+
+/**
+ * Multi exception event test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiExceptionEventTest extends AbstractEventTest
+{
+    /** @var \Ivory\HttpAdapter\MultiHttpAdapterException|\PHPUnit_Framework_MockObject_MockObject */
+    private $exception;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->exception = $this->createExceptionMock();
+
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->exception);
+
+        parent::tearDown();
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\AbstractEvent', $this->event);
+        $this->assertSame($this->httpAdapter, $this->event->getHttpAdapter());
+        $this->assertSame($this->exception, $this->event->getException());
+    }
+
+    public function testSetException()
+    {
+        $this->event->setException($exception = $this->createExceptionMock());
+
+        $this->assertSame($exception, $this->event->getException());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createEvent()
+    {
+        return new MultiExceptionEvent($this->httpAdapter, $this->exception);
+    }
+
+    /**
+     * Creates an exception mock.
+     *
+     * @return \Ivory\HttpAdapter\MulltiHttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The exception mock.
+     */
+    private function createExceptionMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\MultiHttpAdapterException');
+    }
+}

--- a/tests/Event/MultiPostSendEventTest.php
+++ b/tests/Event/MultiPostSendEventTest.php
@@ -1,0 +1,274 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event;
+
+use Ivory\HttpAdapter\Event\MultiPostSendEvent;
+
+/**
+ * Multi post send event test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiPostSendEventTest extends AbstractEventTest
+{
+    /** @var array */
+    private $responses;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->responses = array($this->createResponseMock());
+
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->responses);
+
+        parent::tearDown();
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\AbstractEvent', $this->event);
+        $this->assertSame($this->httpAdapter, $this->event->getHttpAdapter());
+        $this->assertTrue($this->event->hasResponses());
+        $this->assertSame($this->responses, $this->event->getResponses());
+        $this->assertFalse($this->event->hasExceptions());
+        $this->assertEmpty($this->event->getExceptions());
+    }
+
+    public function testInitialState()
+    {
+        $this->event = new MultiPostSendEvent($this->httpAdapter, $responses = array());
+
+        $this->assertFalse($this->event->hasResponses());
+        $this->assertSame($responses, $this->event->getResponses());
+    }
+
+    public function testSetResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+
+        $this->assertResponses($responses);
+    }
+
+    public function testAddResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+        $this->event->addResponses($newResponses = array($this->createResponseMock()));
+
+        $this->assertResponses(array_merge($responses, $newResponses));
+    }
+
+    public function testRemoveResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+        $this->event->removeResponses($responses);
+
+        $this->assertNoResponses();
+    }
+
+    public function testClearResponses()
+    {
+        $this->event->setResponses(array($this->createResponseMock()));
+        $this->event->clearResponses();
+
+        $this->assertNoResponses();
+    }
+
+    public function testAddResponse()
+    {
+        $this->event->addResponse($response = $this->createResponseMock());
+
+        $this->assertResponse($response);
+    }
+
+    public function testRemoveResponse()
+    {
+        $this->event->addResponse($response = $this->createResponseMock());
+        $this->event->removeResponse($response);
+
+        $this->assertNoResponse($response);
+    }
+
+    public function testSetExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+
+        $this->assertExceptions($exceptions);
+    }
+
+    public function testAddExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->event->addExceptions($newExceptions = array($this->createExceptionMock()));
+
+        $this->assertExceptions(array_merge($exceptions, $newExceptions));
+    }
+
+    public function testRemoveExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->event->removeExceptions($exceptions);
+
+        $this->assertNoExceptions();
+    }
+
+    public function testClearExceptions()
+    {
+        $this->event->setExceptions(array($this->createExceptionMock()));
+        $this->event->clearExceptions();
+
+        $this->assertNoExceptions();
+    }
+
+    public function testAddException()
+    {
+        $this->event->addException($exception = $this->createExceptionMock());
+
+        $this->assertException($exception);
+    }
+
+    public function testRemoveException()
+    {
+        $this->event->addException($exception = $this->createExceptionMock());
+        $this->event->removeException($exception);
+
+        $this->assertNoException($exception);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createEvent()
+    {
+        return new MultiPostSendEvent($this->httpAdapter, $this->responses);
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createResponseMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+    }
+
+    /**
+     * Creates an exception mock;
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The exception mock.
+     */
+    private function createExceptionMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterException');
+    }
+
+    /**
+     * Asserts there are the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    private function assertExceptions(array $exceptions)
+    {
+        $this->assertTrue($this->event->hasExceptions());
+        $this->assertSame($exceptions, $this->event->getExceptions());
+
+        foreach ($exceptions as $exception) {
+            $this->assertException($exception);
+        }
+    }
+
+    /**
+     * Asserts there are no exceptions.
+     */
+    private function assertNoExceptions()
+    {
+        $this->assertFalse($this->event->hasExceptions());
+        $this->assertEmpty($this->event->getExceptions());
+    }
+
+    /**
+     * Asserts there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    private function assertException($exception)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\HttpAdapterException', $exception);
+        $this->assertTrue($this->event->hasException($exception));
+    }
+
+    /**
+     * Asserts there is no exception.
+     *
+     * @param string $exception The exception.
+     */
+    private function assertNoException($exception)
+    {
+        $this->assertFalse($this->event->hasException($exception));
+    }
+
+    /**
+     * Asserts there are the responses.
+     *
+     * @param array $responses The responses.
+     */
+    private function assertResponses(array $responses)
+    {
+        $this->assertTrue($this->event->hasResponses());
+        $this->assertSame($responses, $this->event->getResponses());
+
+        foreach ($responses as $response) {
+            $this->assertResponse($response);
+        }
+    }
+
+    /**
+     * Asserts there are no responses.
+     */
+    private function assertNoResponses()
+    {
+        $this->assertFalse($this->event->hasResponses());
+        $this->assertEmpty($this->event->getResponses());
+    }
+
+    /**
+     * Asserts there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    private function assertResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertTrue($this->event->hasResponse($response));
+    }
+
+    /**
+     * Asserts there is no response.
+     *
+     * @param string $response The response.
+     */
+    private function assertNoResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertFalse($this->event->hasResponse($response));
+    }
+}

--- a/tests/Event/MultiPreSendEventTest.php
+++ b/tests/Event/MultiPreSendEventTest.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event;
+
+use Ivory\HttpAdapter\Event\MultiPreSendEvent;
+
+/**
+ * Multi pre send event test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiPreSendEventTest extends AbstractEventTest
+{
+    /** @var array */
+    private $requests;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->requests = array($this->createRequestMock());
+
+        parent::setUp();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->requests);
+
+        parent::tearDown();
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\AbstractEvent', $this->event);
+        $this->assertSame($this->httpAdapter, $this->event->getHttpAdapter());
+        $this->assertTrue($this->event->hasRequests());
+        $this->assertSame($this->requests, $this->event->getRequests());
+    }
+
+    public function testInitialState()
+    {
+        $this->event = new MultiPreSendEvent($this->httpAdapter, $requests = array());
+
+        $this->assertNoRequests();
+    }
+
+    public function testSetRequests()
+    {
+        $this->event->setRequests($requests = array($this->createRequestMock()));
+
+        $this->assertRequests($requests);
+    }
+
+    public function testAddRequests()
+    {
+        $this->event->setRequests($requests = array($this->createRequestMock()));
+        $this->event->addRequests($newRequests = array($this->createRequestMock()));
+
+        $this->assertRequests(array_merge($requests, $newRequests));
+    }
+
+    public function testRemoveRequests()
+    {
+        $this->event->setRequests($requests = array($this->createRequestMock()));
+        $this->event->removeRequests($requests);
+
+        $this->assertNoRequests();
+    }
+
+    public function testClearRequests()
+    {
+        $this->event->setRequests(array($this->createRequestMock()));
+        $this->event->clearRequests();
+
+        $this->assertNoRequests();
+    }
+
+    public function testAddRequest()
+    {
+        $this->event->addRequest($request = $this->createRequestMock());
+
+        $this->assertRequest($request);
+    }
+
+    public function testRemoveRequest()
+    {
+        $this->event->addRequest($request = $this->createRequestMock());
+        $this->event->removeRequest($request);
+
+        $this->assertNoRequest($request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function createEvent()
+    {
+        return new MultiPreSendEvent($this->httpAdapter, $this->requests);
+    }
+
+    /**
+     * Creates a request mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject The request mock.
+     */
+    private function createRequestMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\InternalRequestInterface');
+    }
+
+    /**
+     * Asserts there are the requests.
+     *
+     * @param array $requests The requests.
+     */
+    private function assertRequests(array $requests)
+    {
+        $this->assertTrue($this->event->hasRequests());
+        $this->assertSame($requests, $this->event->getRequests());
+
+        foreach ($requests as $request) {
+            $this->assertRequest($request);
+        }
+    }
+
+    /**
+     * Asserts there are no requests.
+     */
+    private function assertNoRequests()
+    {
+        $this->assertFalse($this->event->hasRequests());
+        $this->assertEmpty($this->event->getRequests());
+    }
+
+    /**
+     * Asserts there is a request.
+     *
+     * @param \Ivory\HttpAdapter\Message\RequestInterface $request The request.
+     */
+    private function assertRequest($request)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\RequestInterface', $request);
+        $this->assertTrue($this->event->hasRequest($request));
+    }
+
+    /**
+     * Asserts there is no request.
+     *
+     * @param string $request The request.
+     */
+    private function assertNoRequest($request)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\RequestInterface', $request);
+        $this->assertFalse($this->event->hasRequest($request));
+    }
+}

--- a/tests/Event/Redirect/RedirectTest.php
+++ b/tests/Event/Redirect/RedirectTest.php
@@ -167,7 +167,7 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
             ->method('getParameter')
             ->will($this->returnValueMap(array(
                 array(Redirect::REDIRECT_COUNT, $redirectCount),
-                array(Redirect::PARENT_REQUEST, $rootRequest = $this->createRequestMock())
+                array(Redirect::PARENT_REQUEST, $rootRequest = $this->createRequestMock()),
             )));
 
         $this->redirect->setThrowException(true);

--- a/tests/Event/Subscriber/AbstractSubscriberTest.php
+++ b/tests/Event/Subscriber/AbstractSubscriberTest.php
@@ -12,6 +12,9 @@
 namespace Ivory\Tests\HttpAdapter\Event\Subscriber;
 
 use Ivory\HttpAdapter\Event\ExceptionEvent;
+use Ivory\HttpAdapter\Event\MultiExceptionEvent;
+use Ivory\HttpAdapter\Event\MultiPostSendEvent;
+use Ivory\HttpAdapter\Event\MultiPreSendEvent;
 use Ivory\HttpAdapter\Event\PostSendEvent;
 use Ivory\HttpAdapter\Event\PreSendEvent;
 use Ivory\HttpAdapter\HttpAdapterInterface;
@@ -80,6 +83,52 @@ abstract class AbstractSubscriberTest extends \PHPUnit_Framework_TestCase
         return new ExceptionEvent(
             $httpAdapter ?: $this->createHttpAdapterMock(),
             $exception ?: $this->createExceptionMock()
+        );
+    }
+
+    /**
+     * Creates a multi pre send event.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface|null $httpAdapter The http adapter.
+     * @param array                                        $requests    The requuests.
+     *
+     * @return \Ivory\HttpAdapter\Event\MultiPreSendEvent The multi pre send event.
+     */
+    protected function createMultiPreSendEvent(HttpAdapterInterface $httpAdapter = null, array $requests = array())
+    {
+        return new MultiPreSendEvent($httpAdapter ?: $this->createHttpAdapterMock(), $requests);
+    }
+
+    /**
+     * Creates a multi post send event.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface|null $httpAdapter The http adapter.
+     * @param array                                        $responses   The responses.
+     *
+     * @return \Ivory\HttpAdapter\Event\MultiPostSendEvent The multi post send event.
+     */
+    protected function createMultiPostSendEvent(HttpAdapterInterface $httpAdapter = null, array $responses = array())
+    {
+        return new MultiPostSendEvent($httpAdapter ?: $this->createHttpAdapterMock(), $responses);
+    }
+
+    /**
+     * Creates a multi exception event.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface|null $httpAdapter The http adapter.
+     * @param array                                        $exceptions  The exceptions.
+     * @param array                                        $responses   The responses.
+     *
+     * @return \Ivory\HttpAdapter\Event\MultiExceptionEvent The multi exception event.
+     */
+    protected function createMultiExceptionEvent(
+        HttpAdapterInterface $httpAdapter = null,
+        array $exceptions = array(),
+        array $responses = array()
+    ) {
+        return new MultiExceptionEvent(
+            $httpAdapter ?: $this->createHttpAdapterMock(),
+            $this->createMultiExceptionMock($exceptions, $responses)
         );
     }
 
@@ -173,6 +222,40 @@ abstract class AbstractSubscriberTest extends \PHPUnit_Framework_TestCase
                 ->method('getResponse')
                 ->will($this->returnValue($response));
         }
+
+        return $exception;
+    }
+
+    /**
+     * Creates a multi exception mock.
+     *
+     * @param array $exceptions The exceptions.
+     * @param array $responses  The responses.
+     *
+     * @return \Ivory\HttpAdapter\MultiHttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The multi exception mock.
+     */
+    protected function createMultiExceptionMock(array $exceptions = array(), array $responses = array())
+    {
+        $exception = $this->getMock('Ivory\HttpAdapter\MultiHttpAdapterException');
+        $exception
+            ->expects($this->any())
+            ->method('hasExceptions')
+            ->will($this->returnValue(!empty($exceptions)));
+
+        $exception
+            ->expects($this->any())
+            ->method('getExceptions')
+            ->will($this->returnValue($exceptions));
+
+        $exception
+            ->expects($this->any())
+            ->method('hasResponses')
+            ->will($this->returnValue(!empty($responses)));
+
+        $exception
+            ->expects($this->any())
+            ->method('getResponses')
+            ->will($this->returnValue($responses));
 
         return $exception;
     }

--- a/tests/Event/Subscriber/BasicAuthSubscriberTest.php
+++ b/tests/Event/Subscriber/BasicAuthSubscriberTest.php
@@ -62,6 +62,9 @@ class BasicAuthSubscriberTest extends AbstractSubscriberTest
 
         $this->assertArrayHasKey(Events::PRE_SEND, $events);
         $this->assertSame(array('onPreSend', 300), $events[Events::PRE_SEND]);
+
+        $this->assertArrayHasKey(Events::MULTI_PRE_SEND, $events);
+        $this->assertSame(array('onMultiPreSend', 300), $events[Events::MULTI_PRE_SEND]);
     }
 
     public function testPreSendEvent()
@@ -72,6 +75,18 @@ class BasicAuthSubscriberTest extends AbstractSubscriberTest
             ->with($this->identicalTo($request = $this->createRequestMock()));
 
         $this->basicAuthSubscriber->onPreSend($this->createPreSendEvent(null, $request));
+    }
+
+    public function testMultiPreSendEvent()
+    {
+        $requests = array($request1 = $this->createRequestMock(), $request2 = $this->createRequestMock());
+
+        $this->basicAuth
+            ->expects($this->exactly(count($requests)))
+            ->method('authenticate')
+            ->withConsecutive(array($request1), array($request2));
+
+        $this->basicAuthSubscriber->onMultiPreSend($this->createMultiPreSendEvent(null, $requests));
     }
 
     /**

--- a/tests/MultiHttpAdapterExceptionTest.php
+++ b/tests/MultiHttpAdapterExceptionTest.php
@@ -1,0 +1,266 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter;
+
+use Ivory\HttpAdapter\MultiHttpAdapterException;
+
+/**
+ * Multi http adapter exception test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class MultiHttpAdapterExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Ivory\HttpAdapter\MultiHttpAdapterException */
+    private $multiHttpAdapterException;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->multiHttpAdapterException = new MultiHttpAdapterException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->multiHttpAdapterException);
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertSame(
+            'An error occured when sending multiple requests.',
+            $this->multiHttpAdapterException->getMessage()
+        );
+
+        $this->assertNoExceptions();
+        $this->assertNoResponses();
+    }
+
+    public function testInitialState()
+    {
+        $this->multiHttpAdapterException = new MultiHttpAdapterException(
+            $exceptions = array($this->createExceptionMock()),
+            $responses = array($this->createResponseMock())
+        );
+
+        $this->assertExceptions($exceptions);
+        $this->assertResponses($responses);
+    }
+
+    public function testSetExceptions()
+    {
+        $this->multiHttpAdapterException->setExceptions($exceptions = array($this->createExceptionMock()));
+
+        $this->assertExceptions($exceptions);
+    }
+
+    public function testAddExceptions()
+    {
+        $this->multiHttpAdapterException->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->multiHttpAdapterException->addExceptions($newExceptions = array($this->createExceptionMock()));
+
+        $this->assertExceptions(array_merge($exceptions, $newExceptions));
+    }
+
+    public function testRemoveExceptions()
+    {
+        $this->multiHttpAdapterException->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->multiHttpAdapterException->removeExceptions($exceptions);
+
+        $this->assertNoExceptions();
+    }
+
+    public function testClearExceptions()
+    {
+        $this->multiHttpAdapterException->setExceptions(array($this->createExceptionMock()));
+        $this->multiHttpAdapterException->clearExceptions();
+
+        $this->assertNoExceptions();
+    }
+
+    public function testAddException()
+    {
+        $this->multiHttpAdapterException->addException($exception = $this->createExceptionMock());
+
+        $this->assertException($exception);
+    }
+
+    public function testRemoveException()
+    {
+        $this->multiHttpAdapterException->addException($exception = $this->createExceptionMock());
+        $this->multiHttpAdapterException->removeException($exception);
+
+        $this->assertNoException($exception);
+    }
+
+    public function testSetResponses()
+    {
+        $this->multiHttpAdapterException->setResponses($responses = array($this->createResponseMock()));
+
+        $this->assertResponses($responses);
+    }
+
+    public function testAddResponses()
+    {
+        $this->multiHttpAdapterException->setResponses($responses = array($this->createResponseMock()));
+        $this->multiHttpAdapterException->addResponses($newResponses = array($this->createResponseMock()));
+
+        $this->assertResponses(array_merge($responses, $newResponses));
+    }
+
+    public function testRemoveResponses()
+    {
+        $this->multiHttpAdapterException->setResponses($responses = array($this->createResponseMock()));
+        $this->multiHttpAdapterException->removeResponses($responses);
+
+        $this->assertNoResponses();
+    }
+
+    public function testClearResponses()
+    {
+        $this->multiHttpAdapterException->setResponses(array($this->createResponseMock()));
+        $this->multiHttpAdapterException->clearResponses();
+
+        $this->assertNoResponses();
+    }
+
+    public function testAddResponse()
+    {
+        $this->multiHttpAdapterException->addResponse($response = $this->createResponseMock());
+
+        $this->assertResponse($response);
+    }
+
+    public function testRemoveResponse()
+    {
+        $this->multiHttpAdapterException->addResponse($response = $this->createResponseMock());
+        $this->multiHttpAdapterException->removeResponse($response);
+
+        $this->assertNoResponse($response);
+    }
+
+    /**
+     * Creates an exception mock.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The exception mock.
+     */
+    private function createExceptionMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterException');
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createResponseMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+    }
+
+    /**
+     * Asserts there are the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    private function assertExceptions(array $exceptions)
+    {
+        $this->assertTrue($this->multiHttpAdapterException->hasExceptions());
+        $this->assertSame($exceptions, $this->multiHttpAdapterException->getExceptions());
+
+        foreach ($exceptions as $exception) {
+            $this->assertException($exception);
+        }
+    }
+
+    /**
+     * Asserts there are no exceptions.
+     */
+    private function assertNoExceptions()
+    {
+        $this->assertFalse($this->multiHttpAdapterException->hasExceptions());
+        $this->assertEmpty($this->multiHttpAdapterException->getExceptions());
+    }
+
+    /**
+     * Asserts there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    private function assertException($exception)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\HttpAdapterException', $exception);
+        $this->assertTrue($this->multiHttpAdapterException->hasException($exception));
+    }
+
+    /**
+     * Asserts there is no exception.
+     *
+     * @param string $exception The exception.
+     */
+    private function assertNoException($exception)
+    {
+        $this->assertFalse($this->multiHttpAdapterException->hasException($exception));
+    }
+
+    /**
+     * Asserts there are the responses.
+     *
+     * @param array $responses The responses.
+     */
+    private function assertResponses(array $responses)
+    {
+        $this->assertTrue($this->multiHttpAdapterException->hasResponses());
+        $this->assertSame($responses, $this->multiHttpAdapterException->getResponses());
+
+        foreach ($responses as $response) {
+            $this->assertResponse($response);
+        }
+    }
+
+    /**
+     * Asserts there are no responses.
+     */
+    private function assertNoResponses()
+    {
+        $this->assertFalse($this->multiHttpAdapterException->hasResponses());
+        $this->assertEmpty($this->multiHttpAdapterException->getResponses());
+    }
+
+    /**
+     * Asserts there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    private function assertResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertTrue($this->multiHttpAdapterException->hasResponse($response));
+    }
+
+    /**
+     * Asserts there is no response.
+     *
+     * @param string $response The response.
+     */
+    private function assertNoResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertFalse($this->multiHttpAdapterException->hasResponse($response));
+    }
+}

--- a/tests/StopwatchHttpAdapterTest.php
+++ b/tests/StopwatchHttpAdapterTest.php
@@ -169,7 +169,8 @@ class StopwatchHttpAdapterTest extends \PHPUnit_Framework_TestCase
             array('delete'),
             array('options'),
             array('send', array('url', RequestInterface::METHOD_GET)),
-            array('sendRequest', array($this->getMock('Psr\Http\Message\OutgoingRequestInterface')), 'sendRequest'),
+            array('sendRequest', array($this->createRequestMock()), 'sendRequest'),
+            array('sendRequests', array(array($this->createRequestMock())), 'sendRequests'),
         );
     }
 
@@ -201,5 +202,15 @@ class StopwatchHttpAdapterTest extends \PHPUnit_Framework_TestCase
     private function createStopwatchMock()
     {
         return $this->getMock('Symfony\Component\Stopwatch\Stopwatch');
+    }
+
+    /**
+     * Creates a request mock.
+     *
+     * @return \Psr\Http\Message\OutgoingRequestInterface|\PHPUnit_Framework_MockObject_MockObject The request mock.
+     */
+    private function createRequestMock()
+    {
+        return $this->getMock('Psr\Http\Message\OutgoingRequestInterface');
     }
 }


### PR DESCRIPTION
This PR is a proposal for parallel requests support. It closes #47 and #31.

To send multi requests, you need to use the `sendRequests` method which takes a unique parameter: an array of requests.

``` php
// A request can be a string (url), an array (url, method, etc) or a psr request.
$requests = array(
    'http://egeloen.fr',
    array('http://egeloen.fr', 'POST'),
    new Request(),
    new InternalRequest(),
);

try {
    $responses = $httpAdapter->sendRequests($requests);
} catch (MultiHttpAdapterException $e) {
    $responses = $e->getResponses();
    $exceptions = $e->getExceptions();
}
```

For the responses, you get a psr response where the request is available as parameter:

``` php
foreach ($responses as $response) {
    $request = $response->getParameter('request');
}
```

For the exceptions, each one wraps the request and the response if available:

``` php
foreach ($exceptions as $exception) {
    $request = $exception->getRequest();

    if ($exception->hasResponse()) {
        $response = $exception->getResponse();
    }
}
```

As you can see, it does not work same as #47 but IMO, it is better to go this way and don't use callable. Futhermore, as the event system is working, you can still hook into the process using the event system.

I still have to work on it but here, we have something which starts to work well! :)

ping @kbond
