### PR TITLE
Enable baseUrl support for GuzzleHttpHttpAdapter

### DIFF
--- a/src/GuzzleHttpHttpAdapter.php
+++ b/src/GuzzleHttpHttpAdapter.php
@@ -51,6 +51,20 @@ class GuzzleHttpHttpAdapter extends AbstractCurlHttpAdapter
     /**
      * {@inheritdoc}
      */
+    public function send($url, $method, array $headers = array(), $datas = array(), array $files = array())
+    {
+        $baseUrl = $this->client->getBaseUrl();
+
+        if (!empty($baseUrl) && false === stripos($url, $baseUrl)) {
+            $url = $baseUrl . $url;
+        }
+
+        return parent::send($url, $method, $headers, $datas, $files);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function doSendInternalRequest(InternalRequestInterface $internalRequest)
     {
         $request = $this->client->createRequest(

--- a/tests/GuzzleHttpCurlHttpAdapterTest.php
+++ b/tests/GuzzleHttpCurlHttpAdapterTest.php
@@ -12,7 +12,10 @@
 namespace Ivory\Tests\HttpAdapter;
 
 use GuzzleHttp\Adapter\Curl\CurlAdapter;
+use GuzzleHttp\Client;
 use GuzzleHttp\Ring\Client\CurlHandler;
+use Ivory\HttpAdapter\GuzzleHttpHttpAdapter;
+use Ivory\Tests\HttpAdapter\Utility\PHPUnitUtility;
 
 /**
  * Guzzle http curl http adapter test.
@@ -43,5 +46,46 @@ class GuzzleHttpCurlHttpAdapterTest extends AbstractGuzzleHttpCurlHttpAdapterTes
         }
 
         return new CurlAdapter($this->createMessageFactory());
+    }
+
+    /**
+     * Tests a relative path when a base URL has been set in the GuzzleHttp client
+     *
+     * @dataProvider simplePlusRelativeProvider
+     *
+     * @param string $url
+     * @param array $headers
+     */
+    public function testGetWithBaseUrl($url, array $headers = array())
+    {
+        if (!($baseUrl = PHPUnitUtility::getUrl())) {
+            $this->markTestSkipped();
+        }
+
+        $http = new GuzzleHttpHttpAdapter(
+            new Client(
+                array(
+                    'base_url' => $baseUrl,
+                    'adapter' => $this->createAdapter()
+                )
+            )
+        );
+
+        $this->assertResponse($http->get($url, $headers));
+    }
+
+    /**
+     * Gets the request provider.
+     *
+     * @return array The request provider.
+     */
+    public function simplePlusRelativeProvider()
+    {
+        return array_merge(
+            $this->simpleProvider(),
+            array(
+                array('/'),
+            )
+        );
     }
 }


### PR DESCRIPTION
GuzzleHttp allows the definition of a base URL when creating a Client:

``` php
use GuzzleHttp\Client;
use Ivory\HttpAdapter\GuzzleHttpHttpAdapter;

$client = new Client(array('base_url' => 'http://api.example.com'));
$http = new GuzzleHttpHttpAdapter($client);

$response = $http->get('/');
```

The last call will throw the following exception:

``` bash
Ivory\HttpAdapter\HttpAdapterException: The url "/" is not valid.
```

because somewhere along the way, [`UrlNormalizer::normalize($url)`](https://github.com/egeloen/ivory-http-adapter/blob/master/src/Normalizer/UrlNormalizer.php#L35) expects an absolute URL, but receives the relative one.

This PR wants to add the following behavior to the `GuzzleHttpHttpAdapter`
- If a base URL has been set in the client, combine the given URL with the base URL from the client
- If a base URL has been set, but the given URL is an absolute URL matching the base URL, don't combine them.

A test is also included (I hope I have put it in the right location :))

Cheers
:octocat: Jérôme
