### PR TITLE
[WIP] Add OAuth2 Subscriber

### DIFF
--- a/src/Event/OAuth2/Configuration.php
+++ b/src/Event/OAuth2/Configuration.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\OAuth2;
+
+use Ivory\HttpAdapter\Event\OAuth2\Grant\GrantInterface;
+use Ivory\HttpAdapter\Normalizer\UrlNormalizer;
+
+/**
+ * OAuth2 Configuration
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * The client id.
+     *
+     * @var string
+     */
+    private $clientId;
+
+    /**
+     * The client secret.
+     *
+     * @var string
+     */
+    private $clientSecret;
+
+    /**
+     * The scopes.
+     *
+     * @var array
+     */
+    private $scopes;
+
+    /**
+     * The scope separator.
+     *
+     * The default is a space, as defined in http://tools.ietf.org/html/rfc6749#section-3.3
+     *
+     * @var string
+     */
+    private $scopeSeparator = ' ';
+
+    /**
+     * The authorization url.
+     *
+     * @var string
+     */
+    private $authorizationUrl;
+
+    /**
+     * The access token url.
+     *
+     * @var string
+     */
+    private $accessTokenUrl;
+
+    /**
+     * The authorization handler url.
+     *
+     * @var string
+     */
+    private $authorizationHandlerUrl;
+
+    /**
+     * The grant.
+     *
+     * @var GrantInterface
+     */
+    private $grant;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClientId()
+    {
+        return $this->clientId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setClientId($clientId)
+    {
+        $this->clientId = $clientId;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getClientSecret()
+    {
+        return $this->clientSecret;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setClientSecret($clientSecret)
+    {
+        $this->clientSecret = $clientSecret;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScopes()
+    {
+        return $this->scopes;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setScopes(array $scopes)
+    {
+        $this->scopes = $scopes;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getScopeSeparator()
+    {
+        return $this->scopeSeparator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setScopeSeparator($scopeSeparator)
+    {
+        $this->scopeSeparator = $scopeSeparator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizationUrl()
+    {
+        return $this->authorizationUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAuthorizationUrl($url)
+    {
+        $this->authorizationUrl = UrlNormalizer::normalize($url);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizationHandlerUrl()
+    {
+        return $this->authorizationHandlerUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAuthorizationHandlerUrl($url)
+    {
+        $this->authorizationHandlerUrl = UrlNormalizer::normalize($url);
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessTokenUrl()
+    {
+        return $this->accessTokenUrl;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAccessTokenUrl($url)
+    {
+        $this->accessTokenUrl = UrlNormalizer::normalize($url);
+    }
+}

--- a/src/Event/OAuth2/ConfigurationInterface.php
+++ b/src/Event/OAuth2/ConfigurationInterface.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\OAuth2;
+
+/**
+ * OAuth2.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+interface ConfigurationInterface
+{
+    /**
+     * @return string
+     */
+    public function getClientId();
+
+    /**
+     * @param string $clientId
+     *
+     * @return void
+     */
+    public function setClientId($clientId);
+
+    /**
+     * @return string
+     */
+    public function getClientSecret();
+
+    /**
+     * @param string $clientSecret
+     *
+     * @return void
+     */
+    public function setClientSecret($clientSecret);
+
+    /**
+     * @return array
+     */
+    public function getScopes();
+
+    /**
+     * @param array $scopes
+     *
+     * @return mixed
+     */
+    public function setScopes(array $scopes);
+
+    /**
+     * @return string
+     */
+    public function getScopeSeparator();
+
+    /**
+     * @param string $scopeSeparator
+     *
+     * @return void
+     */
+    public function setScopeSeparator($scopeSeparator);
+
+    /**
+     * @return string
+     */
+    public function getAuthorizationUrl();
+
+    /**
+     * @param string $url
+     *
+     * @throws \Ivory\HttpAdapter\HttpAdapterException If the url is invalid.
+     *
+     * @return void
+     */
+    public function setAuthorizationUrl($url);
+
+    /**
+     * @return string
+     */
+    public function getAuthorizationHandlerUrl();
+
+    /**
+     * @param string $url
+     *
+     * @return void
+     */
+    public function setAuthorizationHandlerUrl($url);
+
+    /**
+     * @return string
+     */
+    public function getAccessTokenUrl();
+
+    /**
+     * @param string $url
+     *
+     * @throws \Ivory\HttpAdapter\HttpAdapterException If the url is invalid.
+     *
+     * @return void
+     */
+    public function setAccessTokenUrl($url);
+}

--- a/src/Event/OAuth2/Grant/AuthorizationCodeGrant.php
+++ b/src/Event/OAuth2/Grant/AuthorizationCodeGrant.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace Ivory\HttpAdapter\Event\OAuth2\Grant;
+
+use Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken;
+use Ivory\HttpAdapter\Event\OAuth2\OAuth2Exception;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Ivory\HttpAdapter\Message\Stream\StringStream;
+
+/**
+ * OAuth2 Grant.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class AuthorizationCodeGrant implements GrantInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return 'authorization_code';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepareRequest(RequestInterface $request, array $options = array())
+    {
+        if (!isset($options['code']) || empty($options['code'])) {
+            throw new \InvalidArgumentException('Missing code');
+        }
+
+        parse_str($request->getBody()->getContents(), $data);
+
+        $data += array('code' => $options['code']);
+
+        $dataString = http_build_query($data, null, '&');
+
+        $stream = new StringStream($dataString);
+
+        $request->setBody($stream);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleResponse(ResponseInterface $response)
+    {
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new AccessToken($data);
+    }
+}

--- a/src/Event/OAuth2/Grant/GrantInterface.php
+++ b/src/Event/OAuth2/Grant/GrantInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace Ivory\HttpAdapter\Event\OAuth2\Grant;
+
+use Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+/**
+ * OAuth2 Grant.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+interface GrantInterface
+{
+    /**
+     * String representation of this grant.
+     *
+     * @return string
+     */
+    public function __toString();
+
+    /**
+     * @param RequestInterface $request
+     * @param array $options
+     *
+     * @return void
+     */
+    public function prepareRequest(RequestInterface $request, array $options = array());
+
+    /**
+     * @param ResponseInterface $response
+     *
+     * @return \Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken
+     */
+    public function handleResponse(ResponseInterface $response);
+}

--- a/src/Event/OAuth2/Grant/RefreshTokenGrant.php
+++ b/src/Event/OAuth2/Grant/RefreshTokenGrant.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace Ivory\HttpAdapter\Event\OAuth2\Grant;
+
+use Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken;
+use Ivory\HttpAdapter\Event\OAuth2\OAuth2Exception;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Ivory\HttpAdapter\Message\Stream\StringStream;
+
+/**
+ * OAuth2 Grant.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class RefreshTokenGrant implements GrantInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function __toString()
+    {
+        return 'refresh_token';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function prepareRequest(RequestInterface $request, array $options = array())
+    {
+        if (!isset($options['refresh_token']) || empty($options['refresh_token'])) {
+            throw new \InvalidArgumentException('Missing refresh token');
+        }
+
+        parse_str($request->getBody()->getContents(), $data);
+
+        $data += array('refresh_token' => $options['refresh_token']);
+
+        $dataString = http_build_query($data, null, '&');
+
+        $stream = new StringStream($dataString);
+
+        $request->setBody($stream);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function handleResponse(ResponseInterface $response)
+    {
+        $data = json_decode($response->getBody()->getContents(), true);
+
+        return new AccessToken($data);
+    }
+}

--- a/src/Event/OAuth2/OAuth2.php
+++ b/src/Event/OAuth2/OAuth2.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace Ivory\HttpAdapter\Event\OAuth2;
+
+use Ivory\HttpAdapter\Event\OAuth2\Grant\GrantInterface;
+use Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken;
+use Ivory\HttpAdapter\HttpAdapterInterface;
+use Ivory\HttpAdapter\Message;
+use Ivory\HttpAdapter\Message\Request;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\Stream\StringStream;
+
+/**
+ * OAuth2.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class OAuth2 implements OAuth2Interface
+{
+    /**
+     * @var Configuration
+     */
+    private $configuration;
+
+    /**
+     * @var HttpAdapterInterface
+     */
+    private $httpAdapter;
+
+    /**
+     * @param HttpAdapterInterface $httpAdapter
+     * @param ConfigurationInterface $configuration
+     */
+    public function __construct(HttpAdapterInterface $httpAdapter, ConfigurationInterface $configuration)
+    {
+        $this->httpAdapter = $httpAdapter;
+        $this->setConfiguration($configuration);
+    }
+
+    /**
+     * Gets the http adapter.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterInterface The http adapter.
+     */
+    public function getHttpAdapter()
+    {
+        return $this->httpAdapter;
+    }
+
+    /**
+     * Sets the http adapter.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface $httpAdapter The http adapter.
+     */
+//    public function setHttpAdapter(HttpAdapterInterface $httpAdapter)
+//    {
+//        $this->httpAdapter = $httpAdapter;
+//    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration()
+    {
+        return $this->configuration;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAuthorizationUrl(array $options = array())
+    {
+        $params = array_merge(
+            array(
+                'client_id' => $this->configuration->getClientId(),
+                'client_secret' => $this->configuration->getClientSecret(),
+                'redirect_uri' => $this->configuration->getAuthorizationHandlerUrl(),
+                'response_type' => 'code',
+                'scope' => implode($this->configuration->getScopeSeparator(), $this->configuration->getScopes()),
+                'state' => md5(uniqid(rand(), true))
+            ),
+            $options
+        );
+
+        return sprintf('%s?%s', $this->configuration->getAuthorizationUrl(), http_build_query($params));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAccessToken(GrantInterface $grant, array $options = array())
+    {
+        $request = new Request(
+            $this->configuration->getAccessTokenUrl(),
+            Request::METHOD_POST
+        );
+
+        $data = array(
+            'client_id' => $this->configuration->getClientId(),
+            'client_secret' => $this->configuration->getClientSecret(),
+            'grant_type' => (string) $grant,
+            'redirect_uri' => $this->configuration->getAuthorizationHandlerUrl(),
+        );
+
+        $dataString = http_build_query($data, null, '&');
+
+        $stream = new StringStream($dataString);
+
+        $request->setBody($stream);
+
+        $grant->prepareRequest($request, $options);
+
+        $response = $this->getHttpAdapter()->sendRequest($request);
+
+        return $grant->handleResponse($response);
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function authenticate(RequestInterface $request, AccessToken $accessToken)
+    {
+        $request->setHeader(
+            'Authorization',
+            sprintf('%s %s', $accessToken->tokenType, $accessToken->accessToken)
+        );
+    }
+}

--- a/src/Event/OAuth2/OAuth2Interface.php
+++ b/src/Event/OAuth2/OAuth2Interface.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\OAuth2;
+
+use Ivory\HttpAdapter\Event\OAuth2\Grant\GrantInterface;
+use Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken;
+use Ivory\HttpAdapter\Message\RequestInterface;
+
+/**
+ * OAuth2.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+interface OAuth2Interface
+{
+    /**
+     * Gets the configuration.
+     *
+     * @return \Ivory\HttpAdapter\Event\Oauth2\ConfigurationInterface
+     */
+    public function getConfiguration();
+
+    /**
+     * Sets the configuration.
+     *
+     * @param ConfigurationInterface $configuration
+     *
+     * @return mixed
+     */
+    public function setConfiguration(ConfigurationInterface $configuration);
+
+    /**
+     * Returns the authorization url.
+     *
+     * @link http://tools.ietf.org/html/rfc6749#section-4.1.1 Authorization request specification
+     *
+     * @param array $options
+     *
+     * @return mixed
+     */
+    public function getAuthorizationUrl(array $options = array());
+
+    /**
+     * Gets the access token.
+     *
+     * @link http://tools.ietf.org/html/rfc6749#section-4.1.3 Access token request specification
+     *
+     * @param GrantInterface $grant The grant.
+     * @param array $options The options.
+     *
+     * @return \Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken
+     */
+    public function getAccessToken(GrantInterface $grant, array $options = array());
+
+    /**
+     * Authenticates a request.
+     *
+     * @param \Ivory\HttpAdapter\Message\RequestInterface $request The request.
+     * @param AccessToken $accessToken The access token.
+     *
+     * @return void
+     */
+    public function authenticate(RequestInterface $request, AccessToken $accessToken);
+}

--- a/src/Event/OAuth2/Token/AccessToken.php
+++ b/src/Event/OAuth2/Token/AccessToken.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace Ivory\HttpAdapter\Event\OAuth2\Token;
+
+/**
+ * OAuth2 Access Token.
+ *
+ * @link http://tools.ietf.org/html/rfc6749#section-5.1 Successful token specification.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class AccessToken
+{
+    /**
+     * The access token.
+     *
+     * @var string
+     */
+    public $accessToken;
+
+    /**
+     * The token type.
+     *
+     * @var string
+     */
+    public $tokenType;
+
+    /**
+     * @var integer
+     */
+    public $expires;
+
+    /**
+     * @var string
+     */
+    public $refreshToken;
+
+    /**
+     * Constructor.
+     *
+     * @param array $data
+     */
+    public function __construct(array $data)
+    {
+        $this->accessToken = $data['access_token'];
+        $this->tokenType = $data['token_type'];
+        $this->expires = isset($data['expires_in']) ? time() + (int) $data['expires_in'] : null;
+        $this->refreshToken = isset($data['refresh_token']) ?: null;
+    }
+}

--- a/src/Event/StatusCode/StatusCodeInterface.php
+++ b/src/Event/StatusCode/StatusCodeInterface.php
@@ -23,7 +23,7 @@ interface StatusCodeInterface
     /**
      * Validates a status code.
      *
-     * @param \Ivory\HttpAdapter\Event\StatusCode\ResponseInterface $response The response.
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
      *
      * @return boolean TRUE if the status code is valid else FALSE.
      */

--- a/tests/Event/OAuth2/ConfigurationTest.php
+++ b/tests/Event/OAuth2/ConfigurationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+ 
+namespace Ivory\Tests\HttpAdapter\Event\OAuth2;
+
+use Ivory\HttpAdapter\Event\OAuth2\Configuration;
+
+/**
+ * Configuration test.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class ConfigurationTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInitializeConfiguration()
+    {
+        $configuration = new Configuration();
+
+        $configuration->setClientId($clientId = 'foo');
+        $configuration->setClientSecret($clientSecret = 'bar');
+        $configuration->setAccessTokenUrl($accessTokenUrl = 'http://example.com/token');
+        $configuration->setAuthorizationUrl($authorizationUrl = 'http://example.com/auth');
+        $configuration->setAuthorizationHandlerUrl($authorizationHandlerUrl = 'http://egeloen.fr/callback');
+        $configuration->setScopes($scopes = array('baz', 'meh'));
+        $configuration->setScopeSeparator($scopeSeparator = '/');
+
+        $this->assertSame($clientId, $configuration->getClientId());
+        $this->assertSame($clientSecret, $configuration->getClientSecret());
+        $this->assertSame($accessTokenUrl, $configuration->getAccessTokenUrl());
+        $this->assertSame($authorizationUrl, $configuration->getAuthorizationUrl());
+        $this->assertSame($authorizationHandlerUrl, $configuration->getAuthorizationHandlerUrl());
+        $this->assertSame($scopes, $configuration->getScopes());
+        $this->assertSame($scopeSeparator, $configuration->getScopeSeparator());
+    }
+}

--- a/tests/Event/OAuth2/OAuth2Test.php
+++ b/tests/Event/OAuth2/OAuth2Test.php
@@ -1,0 +1,219 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\OAuth2;
+
+use Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken;
+use Ivory\HttpAdapter\Event\Oauth2\Configuration;
+use Ivory\HttpAdapter\Event\OAuth2\Grant\AuthorizationCodeGrant;
+use Ivory\HttpAdapter\Event\OAuth2\Grant\RefreshTokenGrant;
+use Ivory\HttpAdapter\Event\OAuth2\OAuth2;
+use Ivory\HttpAdapter\HttpAdapterInterface;
+use Ivory\HttpAdapter\Message\Request;
+
+/**
+ * OAuth2 test.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class OAuth2Test extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Ivory\HttpAdapter\Event\OAuth2\OAuth2 */
+    private $oAuth2;
+
+    /** @var \Ivory\HttpAdapter\Event\Oauth2\Configuration */
+    private $configuration;
+
+    /** @var HttpAdapterInterface|\PHPUnit_Framework_MockObject_MockObject The http adapter mock. */
+    private $httpAdapter;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->httpAdapter = $this->createHttpAdapterMock();
+        $this->configuration = $this->getConfiguration();
+        $this->oAuth2 = new OAuth2($this->httpAdapter, $this->configuration);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->configuration);
+        unset($this->oAuth2);
+    }
+
+    /**
+     * @return \Ivory\HttpAdapter\Event\Oauth2\Configuration
+     */
+    protected function getConfiguration()
+    {
+        $configuration = new Configuration();
+        $configuration->setClientId('foo');
+        $configuration->setClientSecret('bar');
+        $configuration->setAccessTokenUrl('http://example.com/token');
+        $configuration->setAuthorizationUrl('http://example.com/auth');
+        $configuration->setAuthorizationHandlerUrl('http://egeloen.fr/callback');
+        $configuration->setScopes(array('baz', 'qux'));
+
+        return $configuration;
+    }
+
+    public function testInitialState()
+    {
+        $this->assertSame($this->httpAdapter, $this->oAuth2->getHttpAdapter());
+        $this->assertSame($this->configuration, $this->oAuth2->getConfiguration());
+    }
+
+    public function testSetConfiguration()
+    {
+        $this->oAuth2->setConfiguration($configuration = new Configuration());
+
+        $this->assertSame($configuration, $this->oAuth2->getConfiguration());
+    }
+
+    public function testGetAuthorizationUrl()
+    {
+        $url = $this->oAuth2->getAuthorizationUrl(array('state' => $state = md5(uniqid(rand(), true))));
+
+        $query = parse_url($url, PHP_URL_QUERY);
+        parse_str($query, $queryParts);
+
+        $this->assertStringStartsWith($this->configuration->getAuthorizationUrl(), $url);
+        $this->assertEquals($this->configuration->getClientId(), $queryParts['client_id']);
+        $this->assertEquals($this->configuration->getClientSecret(), $queryParts['client_secret']);
+        $this->assertEquals($this->configuration->getAuthorizationHandlerUrl(), $queryParts['redirect_uri']);
+        $this->assertEquals('code', $queryParts['response_type']);
+        $this->assertEquals(
+            $this->configuration->getScopes(),
+            explode($this->configuration->getScopeSeparator(), $queryParts['scope'])
+        );
+        $this->assertEquals($state, $queryParts['state']);
+    }
+
+    public function testGetAccessTokenWithAuthorizationGrant()
+    {
+        $response = $this->createResponseMockForAuthorizationCodeGrant();
+
+        $this->httpAdapter
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->will($this->returnValue($response));
+
+        $token = $this->oAuth2->getAccessToken(new AuthorizationCodeGrant(), array('code' => 'foo'));
+
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken', $token);
+    }
+
+    public function testGetAccessTokenWithAuthorizationGrantAndMissingCode()
+    {
+        $this->setExpectedException('\InvalidArgumentException', 'Missing code');
+
+        $this->oAuth2->getAccessToken(new AuthorizationCodeGrant());
+    }
+
+    public function testGetAccessTokenWithRefreshTokenGrant()
+    {
+        $response = $this->createResponseMockForRefreshTokenGrant();
+
+        $this->httpAdapter
+            ->expects($this->any())
+            ->method('sendRequest')
+            ->will($this->returnValue($response));
+
+        $token = $this->oAuth2->getAccessToken(new RefreshTokenGrant(), array('refresh_token' => 'foo'));
+
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\OAuth2\Token\AccessToken', $token);
+    }
+
+    public function testGetAccessTokenWithRefreshTokenGrantAndMissingRefreshCode()
+    {
+        $this->setExpectedException('\InvalidArgumentException','Missing refresh token');
+
+        $this->oAuth2->getAccessToken(new RefreshTokenGrant());
+    }
+
+    public function testAuthenticate()
+    {
+        $token = new AccessToken(array(
+            'access_token' => $accessTokenString = 'foo',
+            'token_type' => $tokenType = 'bar',
+        ));
+
+        $request = new Request('http://egeloen.fr/', Request::METHOD_GET);
+
+        $this->oAuth2->authenticate($request, $token);
+
+        $this->assertArrayHasKey('Authorization', $request->getHeaders());
+        $this->assertEquals(sprintf('%s %s', $tokenType, $accessTokenString), $request->getHeader('Authorization'));
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createResponseMockForAuthorizationCodeGrant()
+    {
+        $body = $this->getMock('Psr\Http\Message\StreamableInterface');
+        $body
+            ->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(
+                '{"access_token": "foo", "token_type": "Bearer", "expires_in": 3600, "refresh_token": "baz"}'
+            ));
+
+        $response = $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+        $response
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue($body));
+
+        return $response;
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createResponseMockForRefreshTokenGrant()
+    {
+        $body = $this->getMock('Psr\Http\Message\StreamableInterface');
+        $body
+            ->expects($this->any())
+            ->method('getContents')
+            ->will($this->returnValue(
+                '{"access_token": "foo", "token_type": "Bearer", "expires_in": 3600}'
+            ));
+
+        $response = $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+        $response
+            ->expects($this->any())
+            ->method('getBody')
+            ->will($this->returnValue($body));
+
+        return $response;
+    }
+
+    /**
+     * Creates an http adapter mock.
+     *
+     * @return HttpAdapterInterface|\PHPUnit_Framework_MockObject_MockObject The http adapter mock.
+     */
+    private function createHttpAdapterMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterInterface');
+    }
+}


### PR DESCRIPTION
Salut Eric,

this is a very rough first implementation of an OAuth2 subscriber, that I've been working on since yesterday. It currently only supports the Authorization Code Grant and the Refresh Token Grant, the PHP Doc is not cleaned up, the subscriber itself is not in place yet, and so on :). At least everything is fully tested!

I have published the PR already because of two reasons:
- Would you include an OAuth2 subscriber in your HTTP Adapter at all? :) Or would you rather recommend making it a separate extension in a separate repository?
- Either way, if you can look past the obvious stylistic flaws which are in the code at the moment, I would really appreciate your feedback on this.
- ~~And at last, on my machine, the `Ivory\Event\OAuth2\Configuration` class gets no code coverage although the tests are covering it. I wonder if Travis gets it right.~~ _Update: Turns out that `Oauth2` is not the same as `OAuth2` :smile:_

Cheers
:christmas_tree: Jérôme

PS: I tested the OAuth2 workflow locally and manually with my Spotify account, and it worked great :).