### PR TITLE
Rework multi post/exception event

### DIFF
--- a/doc/events.md
+++ b/doc/events.md
@@ -131,7 +131,7 @@ foreach ($responses as $response) {
 
 The `Ivory\HttpAdapter\Event\Events::MULTI_EXCEPTION` describes the event trigger if an error occurred in a parallel
 requests context. It is represented by the `Ivory\HttpAdapter\Event\MultiExceptionEvent` and wraps the http adapter
-and the multi exception. To get/set them, you can use:
+exceptions. To get/set them, you can use:
 
 ``` php
 use Ivory\HttpAdapter\Event\ExceptionEvent;
@@ -141,19 +141,15 @@ $multiExceptionEvent = new MultiExceptionEvent($httpAdapter, $multiException);
 $httpAdapter = $multiExceptionEvent->getHttpAdapter();
 $multiExceptionEvent->setHttpAdapter($httpAdapter);
 
-$multiException = $multiExceptionEvent->getException();
-$multiExceptionEvent->setException($multiException);
+$exceptions = $multiExceptionEvent->getExceptions();
+$multiExceptionEvent->setExceptions($exceptions);
 ```
 
-The multi exception is an instance of `Ivory\HttpAdapter\MultiHttpAdapterException` which wraps the responses and
-the exceptions. To get/set them, you can use:
+The exception is an instance of `Ivory\HttpAdapter\HttpAdapterException` which wraps the request and the responses if
+available. To get/set them, you can use:
 
 ``` php
-foreach ($mutliException->getResponses() as $response) {
-    $request = $response->getParameter('request');
-}
-
-foreach ($mutliException->getExceptions() as $exception) {
+foreach ($mutliExceptionEvent->getExceptions() as $exception) {
     $request = $exception->getRequest();
 
     if ($exception->hasResponses()) {

--- a/src/Event/MultiExceptionEvent.php
+++ b/src/Event/MultiExceptionEvent.php
@@ -11,8 +11,9 @@
 
 namespace Ivory\HttpAdapter\Event;
 
+use Ivory\HttpAdapter\HttpAdapterException;
 use Ivory\HttpAdapter\HttpAdapterInterface;
-use Ivory\HttpAdapter\MultiHttpAdapterException;
+use Ivory\HttpAdapter\Message\ResponseInterface;
 
 /**
  * Multi exception event.
@@ -21,39 +22,214 @@ use Ivory\HttpAdapter\MultiHttpAdapterException;
  */
 class MultiExceptionEvent extends AbstractEvent
 {
-    /** @var \Ivory\HttpAdapter\MultiHttpAdapterException */
-    private $exception;
+    /** @var array */
+    private $exceptions;
+
+    /** @var array */
+    private $responses = array();
 
     /**
-     * Creates an exception event.
+     * Creates a multi exception event.
      *
-     * @param \Ivory\HttpAdapter\HttpAdapterInterface      $httpAdapter The http adapter.
-     * @param \Ivory\HttpAdapter\MultiHttpAdapterException $exception   The exception.
+     * @param \Ivory\HttpAdapter\HttpAdapterInterface $httpAdapter The http adapter.
+     * @param array                                   $exceptions  The exceptions.
      */
-    public function __construct(HttpAdapterInterface $httpAdapter, MultiHttpAdapterException $exception)
+    public function __construct(HttpAdapterInterface $httpAdapter, array $exceptions)
     {
         parent::__construct($httpAdapter);
 
-        $this->setException($exception);
+        $this->setExceptions($exceptions);
     }
 
     /**
-     * Gets the exception.
-     *
-     * @return \Ivory\HttpAdapter\MultiHttpAdapterException The exception.
+     * Clears the exceptions.
      */
-    public function getException()
+    public function clearExceptions()
     {
-        return $this->exception;
+        $this->exceptions = array();
     }
 
     /**
-     * Sets the exception.
+     * Checks if there are exceptions.
      *
-     * @param \Ivory\HttpAdapter\MultiHttpAdapterException $exception The exception.
+     * @return boolean TRUE if there are exceptions else FALSE.
      */
-    public function setException(MultiHttpAdapterException $exception)
+    public function hasExceptions()
     {
-        $this->exception = $exception;
+        return !empty($this->exceptions);
+    }
+
+    /**
+     * Gets the exceptions.
+     *
+     * @return array The exceptions.
+     */
+    public function getExceptions()
+    {
+        return $this->exceptions;
+    }
+
+    /**
+     * Sets the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function setExceptions(array $exceptions)
+    {
+        $this->clearExceptions();
+        $this->addExceptions($exceptions);
+    }
+
+    /**
+     * Adds the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function addExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->addException($exception);
+        }
+    }
+
+    /**
+     * Removes the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    public function removeExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->removeException($exception);
+        }
+    }
+
+    /**
+     * Checks if there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     *
+     * @return boolean TRUE if there is the exception else FALSE.
+     */
+    public function hasException(HttpAdapterException $exception)
+    {
+        return array_search($exception, $this->exceptions, true) !== false;
+    }
+
+    /**
+     * Adds an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception
+     */
+    public function addException(HttpAdapterException $exception)
+    {
+        $this->exceptions[] = $exception;
+    }
+
+    /**
+     * Removes an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    public function removeException(HttpAdapterException $exception)
+    {
+        unset($this->exceptions[array_search($exception, $this->exceptions, true)]);
+        $this->exceptions = array_values($this->exceptions);
+    }
+
+    /**
+     * Clears the responses.
+     */
+    public function clearResponses()
+    {
+        $this->responses = array();
+    }
+
+    /**
+     * Checks if there are responses.
+     *
+     * @return boolean TRUE if there are responses else FALSE.
+     */
+    public function hasResponses()
+    {
+        return !empty($this->responses);
+    }
+
+    /**
+     * Gets the responses.
+     *
+     * @return array The responses.
+     */
+    public function getResponses()
+    {
+        return $this->responses;
+    }
+
+    /**
+     * Sets the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function setResponses(array $responses)
+    {
+        $this->clearResponses();
+        $this->addResponses($responses);
+    }
+
+    /**
+     * Adds the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function addResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->addResponse($response);
+        }
+    }
+
+    /**
+     * Removes the responses.
+     *
+     * @param array $responses The responses.
+     */
+    public function removeResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->removeResponse($response);
+        }
+    }
+
+    /**
+     * Checks if there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     *
+     * @return boolean TRUE if there is the response else FALSE.
+     */
+    public function hasResponse(ResponseInterface $response)
+    {
+        return array_search($response, $this->responses, true) !== false;
+    }
+
+    /**
+     * Adds a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function addResponse(ResponseInterface $response)
+    {
+        $this->responses[] = $response;
+    }
+
+    /**
+     * Removes a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function removeResponse(ResponseInterface $response)
+    {
+        unset($this->responses[array_search($response, $this->responses, true)]);
+        $this->responses = array_values($this->responses);
     }
 }

--- a/src/Event/Subscriber/CookieSubscriber.php
+++ b/src/Event/Subscriber/CookieSubscriber.php
@@ -125,11 +125,7 @@ class CookieSubscriber implements EventSubscriberInterface
      */
     public function onMultiException(MultiExceptionEvent $event)
     {
-        foreach ($event->getException()->getResponses() as $response) {
-            $this->cookieJar->extract($response->getParameter('request'), $response);
-        }
-
-        foreach ($event->getException()->getExceptions() as $exception) {
+        foreach ($event->getExceptions() as $exception) {
             if ($exception->hasResponse()) {
                 $this->cookieJar->extract($exception->getRequest(), $exception->getResponse());
             }

--- a/src/Event/Subscriber/HistorySubscriber.php
+++ b/src/Event/Subscriber/HistorySubscriber.php
@@ -12,7 +12,6 @@
 namespace Ivory\HttpAdapter\Event\Subscriber;
 
 use Ivory\HttpAdapter\Event\Events;
-use Ivory\HttpAdapter\Event\MultiExceptionEvent;
 use Ivory\HttpAdapter\Event\MultiPostSendEvent;
 use Ivory\HttpAdapter\Event\MultiPreSendEvent;
 use Ivory\HttpAdapter\Event\PostSendEvent;
@@ -111,18 +110,6 @@ class HistorySubscriber extends AbstractTimerSubscriber
     }
 
     /**
-     * On multi exception event.
-     *
-     * @param \Ivory\HttpAdapter\Event\MultiExceptionEvent $event The multi exception event.
-     */
-    public function onMultiException(MultiExceptionEvent $event)
-    {
-        foreach ($event->getException()->getResponses() as $response) {
-            $this->record($response->getParameter('request'), $response);
-        }
-    }
-
-    /**
      * {@inheritdoc}
      */
     public static function getSubscribedEvents()
@@ -132,7 +119,6 @@ class HistorySubscriber extends AbstractTimerSubscriber
             Events::POST_SEND       => array('onPostSend', 100),
             Events::MULTI_PRE_SEND  => array('onMultiPreSend', 100),
             Events::MULTI_POST_SEND => array('onMultiPostSend', 100),
-            Events::MULTI_EXCEPTION => array('onMultiException', 100),
         );
     }
 

--- a/src/Event/Subscriber/LoggerSubscriber.php
+++ b/src/Event/Subscriber/LoggerSubscriber.php
@@ -134,11 +134,7 @@ class LoggerSubscriber extends AbstractFormatterSubscriber
      */
     public function onMultiException(MultiExceptionEvent $event)
     {
-        foreach ($event->getException()->getResponses() as $response) {
-            $this->debug($event->getHttpAdapter(), $response->getParameter('request'), $response);
-        }
-
-        foreach ($event->getException()->getExceptions() as $exception) {
+        foreach ($event->getExceptions() as $exception) {
             $this->error($event->getHttpAdapter(), $exception);
         }
     }

--- a/src/Event/Subscriber/RetrySubscriber.php
+++ b/src/Event/Subscriber/RetrySubscriber.php
@@ -85,10 +85,10 @@ class RetrySubscriber implements EventSubscriberInterface
     {
         $retryRequests = array();
 
-        foreach ($event->getException()->getExceptions() as $exception) {
+        foreach ($event->getExceptions() as $exception) {
             if ($this->retry->retry($exception->getRequest(), false)) {
                 $retryRequests[] = $exception->getRequest();
-                $event->getException()->removeException($exception);
+                $event->removeException($exception);
             }
         }
 
@@ -97,10 +97,10 @@ class RetrySubscriber implements EventSubscriberInterface
         }
 
         try {
-            $event->getException()->addResponses($event->getHttpAdapter()->sendRequests($retryRequests));
+            $event->addResponses($event->getHttpAdapter()->sendRequests($retryRequests));
         } catch (MultiHttpAdapterException $e) {
-            $event->getException()->addResponses($e->getResponses());
-            $event->getException()->addExceptions($e->getExceptions());
+            $event->addResponses($e->getResponses());
+            $event->addExceptions($e->getExceptions());
         }
     }
 

--- a/src/Event/Subscriber/StopwatchSubscriber.php
+++ b/src/Event/Subscriber/StopwatchSubscriber.php
@@ -126,13 +126,7 @@ class StopwatchSubscriber implements EventSubscriberInterface
      */
     public function onMultiException(MultiExceptionEvent $event)
     {
-        foreach ($event->getException()->getResponses() as $response) {
-            $this->stopwatch->stop(
-                $this->getStopwatchName($event->getHttpAdapter(), $response->getParameter('request'))
-            );
-        }
-
-        foreach ($event->getException()->getExceptions() as $exception) {
+        foreach ($event->getExceptions() as $exception) {
             $this->stopwatch->stop(
                 $this->getStopwatchName($event->getHttpAdapter(), $exception->getRequest())
             );

--- a/tests/Event/AbstractEventTest.php
+++ b/tests/Event/AbstractEventTest.php
@@ -44,6 +44,7 @@ abstract class AbstractEventTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultState()
     {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\AbstractEvent', $this->event);
         $this->assertSame($this->httpAdapter, $this->event->getHttpAdapter());
     }
 

--- a/tests/Event/MultiExceptionEventTest.php
+++ b/tests/Event/MultiExceptionEventTest.php
@@ -20,15 +20,15 @@ use Ivory\HttpAdapter\Event\MultiExceptionEvent;
  */
 class MultiExceptionEventTest extends AbstractEventTest
 {
-    /** @var \Ivory\HttpAdapter\MultiHttpAdapterException|\PHPUnit_Framework_MockObject_MockObject */
-    private $exception;
+    /** @var array */
+    private $exceptions;
 
     /**
      * {@inheritdoc}
      */
     protected function setUp()
     {
-        $this->exception = $this->createExceptionMock();
+        $this->exceptions = array($this->createExceptionMock());
 
         parent::setUp();
     }
@@ -38,23 +38,109 @@ class MultiExceptionEventTest extends AbstractEventTest
      */
     protected function tearDown()
     {
-        unset($this->exception);
+        unset($this->exceptions);
 
         parent::tearDown();
     }
 
     public function testDefaultState()
     {
-        $this->assertInstanceOf('Ivory\HttpAdapter\Event\AbstractEvent', $this->event);
-        $this->assertSame($this->httpAdapter, $this->event->getHttpAdapter());
-        $this->assertSame($this->exception, $this->event->getException());
+        parent::testDefaultState();
+
+        $this->assertExceptions($this->exceptions);
+        $this->assertNoResponses();
     }
 
-    public function testSetException()
+    public function testSetExceptions()
     {
-        $this->event->setException($exception = $this->createExceptionMock());
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
 
-        $this->assertSame($exception, $this->event->getException());
+        $this->assertExceptions($exceptions);
+    }
+
+    public function testAddExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->event->addExceptions($newExceptions = array($this->createExceptionMock()));
+
+        $this->assertExceptions(array_merge($exceptions, $newExceptions));
+    }
+
+    public function testRemoveExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->event->removeExceptions($exceptions);
+
+        $this->assertNoExceptions();
+    }
+
+    public function testClearExceptions()
+    {
+        $this->event->setExceptions(array($this->createExceptionMock()));
+        $this->event->clearExceptions();
+
+        $this->assertNoExceptions();
+    }
+
+    public function testAddException()
+    {
+        $this->event->addException($exception = $this->createExceptionMock());
+
+        $this->assertException($exception);
+    }
+
+    public function testRemoveException()
+    {
+        $this->event->addException($exception = $this->createExceptionMock());
+        $this->event->removeException($exception);
+
+        $this->assertNoException($exception);
+    }
+
+    public function testSetResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+
+        $this->assertResponses($responses);
+    }
+
+    public function testAddResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+        $this->event->addResponses($newResponses = array($this->createResponseMock()));
+
+        $this->assertResponses(array_merge($responses, $newResponses));
+    }
+
+    public function testRemoveResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+        $this->event->removeResponses($responses);
+
+        $this->assertNoResponses();
+    }
+
+    public function testClearResponses()
+    {
+        $this->event->setResponses(array($this->createResponseMock()));
+        $this->event->clearResponses();
+
+        $this->assertNoResponses();
+    }
+
+    public function testAddResponse()
+    {
+        $this->event->addResponse($response = $this->createResponseMock());
+
+        $this->assertResponse($response);
+    }
+
+    public function testRemoveResponse()
+    {
+        $this->event->addResponse($response = $this->createResponseMock());
+        $this->event->removeResponse($response);
+
+        $this->assertNoResponse($response);
     }
 
     /**
@@ -62,16 +148,117 @@ class MultiExceptionEventTest extends AbstractEventTest
      */
     protected function createEvent()
     {
-        return new MultiExceptionEvent($this->httpAdapter, $this->exception);
+        return new MultiExceptionEvent($this->httpAdapter, $this->exceptions);
     }
 
     /**
      * Creates an exception mock.
      *
-     * @return \Ivory\HttpAdapter\MulltiHttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The exception mock.
+     * @return \Ivory\HttpAdapter\HttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The exception mock.
      */
     private function createExceptionMock()
     {
-        return $this->getMock('Ivory\HttpAdapter\MultiHttpAdapterException');
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterException');
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createResponseMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+    }
+
+    /**
+     * Asserts there are the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    private function assertExceptions(array $exceptions)
+    {
+        $this->assertTrue($this->event->hasExceptions());
+        $this->assertSame($exceptions, $this->event->getExceptions());
+
+        foreach ($exceptions as $exception) {
+            $this->assertException($exception);
+        }
+    }
+
+    /**
+     * Asserts there are no exceptions.
+     */
+    private function assertNoExceptions()
+    {
+        $this->assertFalse($this->event->hasExceptions());
+        $this->assertEmpty($this->event->getExceptions());
+    }
+
+    /**
+     * Asserts there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    private function assertException($exception)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\HttpAdapterException', $exception);
+        $this->assertTrue($this->event->hasException($exception));
+    }
+
+    /**
+     * Asserts there is no exception.
+     *
+     * @param string $exception The exception.
+     */
+    private function assertNoException($exception)
+    {
+        $this->assertFalse($this->event->hasException($exception));
+    }
+
+    /**
+     * Asserts there are the responses.
+     *
+     * @param array $responses The responses.
+     */
+    private function assertResponses(array $responses)
+    {
+        $this->assertTrue($this->event->hasResponses());
+        $this->assertSame($responses, $this->event->getResponses());
+
+        foreach ($responses as $response) {
+            $this->assertResponse($response);
+        }
+    }
+
+    /**
+     * Asserts there are no responses.
+     */
+    private function assertNoResponses()
+    {
+        $this->assertFalse($this->event->hasResponses());
+        $this->assertEmpty($this->event->getResponses());
+    }
+
+    /**
+     * Asserts there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    private function assertResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertTrue($this->event->hasResponse($response));
+    }
+
+    /**
+     * Asserts there is no response.
+     *
+     * @param string $response The response.
+     */
+    private function assertNoResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertFalse($this->event->hasResponse($response));
     }
 }

--- a/tests/Event/MultiPostSendEventTest.php
+++ b/tests/Event/MultiPostSendEventTest.php
@@ -45,20 +45,10 @@ class MultiPostSendEventTest extends AbstractEventTest
 
     public function testDefaultState()
     {
-        $this->assertInstanceOf('Ivory\HttpAdapter\Event\AbstractEvent', $this->event);
-        $this->assertSame($this->httpAdapter, $this->event->getHttpAdapter());
-        $this->assertTrue($this->event->hasResponses());
-        $this->assertSame($this->responses, $this->event->getResponses());
-        $this->assertFalse($this->event->hasExceptions());
-        $this->assertEmpty($this->event->getExceptions());
-    }
+        parent::testDefaultState();
 
-    public function testInitialState()
-    {
-        $this->event = new MultiPostSendEvent($this->httpAdapter, $responses = array());
-
-        $this->assertFalse($this->event->hasResponses());
-        $this->assertSame($responses, $this->event->getResponses());
+        $this->assertResponses($this->responses);
+        $this->assertNoExceptions();
     }
 
     public function testSetResponses()

--- a/tests/Event/MultiPreSendEventTest.php
+++ b/tests/Event/MultiPreSendEventTest.php
@@ -45,10 +45,9 @@ class MultiPreSendEventTest extends AbstractEventTest
 
     public function testDefaultState()
     {
-        $this->assertInstanceOf('Ivory\HttpAdapter\Event\AbstractEvent', $this->event);
-        $this->assertSame($this->httpAdapter, $this->event->getHttpAdapter());
-        $this->assertTrue($this->event->hasRequests());
-        $this->assertSame($this->requests, $this->event->getRequests());
+        parent::testDefaultState();
+
+        $this->assertRequests($this->requests);
     }
 
     public function testInitialState()

--- a/tests/Event/Subscriber/AbstractSubscriberTest.php
+++ b/tests/Event/Subscriber/AbstractSubscriberTest.php
@@ -117,19 +117,14 @@ abstract class AbstractSubscriberTest extends \PHPUnit_Framework_TestCase
      *
      * @param \Ivory\HttpAdapter\HttpAdapterInterface|null $httpAdapter The http adapter.
      * @param array                                        $exceptions  The exceptions.
-     * @param array                                        $responses   The responses.
      *
      * @return \Ivory\HttpAdapter\Event\MultiExceptionEvent The multi exception event.
      */
     protected function createMultiExceptionEvent(
         HttpAdapterInterface $httpAdapter = null,
-        array $exceptions = array(),
-        array $responses = array()
+        array $exceptions = array()
     ) {
-        return new MultiExceptionEvent(
-            $httpAdapter ?: $this->createHttpAdapterMock(),
-            $this->createMultiExceptionMock($exceptions, $responses)
-        );
+        return new MultiExceptionEvent($httpAdapter ?: $this->createHttpAdapterMock(), $exceptions);
     }
 
     /**

--- a/tests/Event/Subscriber/CookieSubscriberTest.php
+++ b/tests/Event/Subscriber/CookieSubscriberTest.php
@@ -169,33 +169,26 @@ class CookieSubscriberTest extends AbstractSubscriberTest
     {
         $this->cookieSubscriber->setCookieJar($cookieJar = $this->createCookieJarMock());
 
-        $responses = array(
-            $response1 = $this->createResponseMock($request1 = $this->createRequestMock()),
-            $response2 = $this->createResponseMock($request2 = $this->createRequestMock()),
-        );
-
         $exceptions = array(
             $this->createExceptionMock(
-                $request3 = $this->createRequestMock(),
-                $response3 = $this->createResponseMock($request3)
+                $request1 = $this->createRequestMock(),
+                $response1 = $this->createResponseMock($request1)
             ),
             $this->createExceptionMock(
-                $request4 = $this->createRequestMock(),
-                $response4 = $this->createResponseMock($request4)
+                $request2 = $this->createRequestMock(),
+                $response2 = $this->createResponseMock($request2)
             ),
         );
 
         $cookieJar
-            ->expects($this->exactly(count(array_merge($responses, $exceptions))))
+            ->expects($this->exactly(count($exceptions)))
             ->method('extract')
             ->withConsecutive(
                 array($request1, $response1),
-                array($request2, $response2),
-                array($request3, $response3),
-                array($request4, $response4)
+                array($request2, $response2)
             );
 
-        $this->cookieSubscriber->onMultiException($this->createMultiExceptionEvent(null, $exceptions, $responses));
+        $this->cookieSubscriber->onMultiException($this->createMultiExceptionEvent(null, $exceptions));
     }
 
     /**

--- a/tests/Event/Subscriber/HistorySubscriberTest.php
+++ b/tests/Event/Subscriber/HistorySubscriberTest.php
@@ -143,34 +143,6 @@ class HistorySubscriberTest extends AbstractSubscriberTest
         $this->historySubscriber->onMultiPostSend($this->createMultiPostSendEvent(null, $responses));
     }
 
-    public function testMultiExceptionEvent()
-    {
-        $requests = array($request1 = $this->createRequestMock(), $request2 = $this->createRequestMock());
-
-        $responses = array(
-            $response1 = $this->createResponseMock($request1),
-            $response2 = $this->createResponseMock($request2),
-        );
-
-        $this->timer
-            ->expects($this->exactly(count($responses)))
-            ->method('start')
-            ->withConsecutive(array($request1), array($request2));
-
-        $this->timer
-            ->expects($this->exactly(count($responses)))
-            ->method('stop')
-            ->withConsecutive(array($request1), array($request2));
-
-        $this->journal
-            ->expects($this->exactly(count($responses)))
-            ->method('record')
-            ->withConsecutive(array($request1, $response1), array($request2, $response2));
-
-        $this->historySubscriber->onMultiPreSend($this->createMultiPreSendEvent(null, $requests));
-        $this->historySubscriber->onMultiException($this->createMultiExceptionEvent(null, array(), $responses));
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/tests/Event/Subscriber/StopwatchSubscriberTest.php
+++ b/tests/Event/Subscriber/StopwatchSubscriberTest.php
@@ -148,22 +148,16 @@ class StopwatchSubscriberTest extends AbstractSubscriberTest
     public function testMultiExceptionEvent()
     {
         $exceptions = array($this->createExceptionMock(), $this->createExceptionMock());
-        $responses = array(
-            $this->createResponseMock($this->createRequestMock()),
-            $this->createResponseMock($this->createRequestMock()),
-        );
 
         $this->stopwatch
-            ->expects($this->exactly(count(array_merge($exceptions, $responses))))
+            ->expects($this->exactly(count($exceptions)))
             ->method('stop')
             ->withConsecutive(
-                array('ivory.http_adapter.http_adapter (url)'),
-                array('ivory.http_adapter.http_adapter (url)'),
                 array('ivory.http_adapter.http_adapter (url)'),
                 array('ivory.http_adapter.http_adapter (url)')
             );
 
-        $this->stopwatchSubscriber->onMultiException($this->createMultiExceptionEvent(null, $exceptions, $responses));
+        $this->stopwatchSubscriber->onMultiException($this->createMultiExceptionEvent(null, $exceptions));
     }
 
     /**


### PR DESCRIPTION
This PR fixes #56 by triggering the multi post send event regardless if there is an error for other requests and only trigger the multi exception event if there is at least one error.