### PR TITLE
Add Tape Recorder Subscriber

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "satooshi/php-coveralls": "~0.6",
         "symfony/event-dispatcher": "~2.0",
         "zendframework/zendframework1": "^1.12.9",
-        "zendframework/zendframework": "~2.4@dev"
+        "zendframework/zendframework": "~2.4@dev",
+        "symfony/yaml": "~2.6"
     },
     "repositories": [
         {
@@ -48,7 +49,8 @@
         "zendframework/zend-http": "Allows you to use the Zend 2 adapter",
         "psr/log": "Allows you to use the logger event subscriber",
         "symfony/event-dispatcher": "Allows you to use the event lifecycle",
-        "symfony/stopwatch": "Allows you to use the stopwatch http adapter and event subscriber"
+        "symfony/stopwatch": "Allows you to use the stopwatch http adapter and event subscriber",
+        "symfony/yaml": "Allows you to use the Tape Recorder subscriber"
     },
     "autoload": {
         "psr-4": { "Ivory\\HttpAdapter\\": "src/" }

--- a/src/Event/Subscriber/TapeRecorderSubscriber.php
+++ b/src/Event/Subscriber/TapeRecorderSubscriber.php
@@ -1,0 +1,273 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\Subscriber;
+
+use Ivory\HttpAdapter\Event\Events;
+use Ivory\HttpAdapter\Event\ExceptionEvent;
+use Ivory\HttpAdapter\Event\TapeRecorder\Tape;
+use Ivory\HttpAdapter\Event\TapeRecorder\TapeRecorderException;
+use Ivory\HttpAdapter\Event\PostSendEvent;
+use Ivory\HttpAdapter\Event\PreSendEvent;
+use Ivory\HttpAdapter\Event\TapeRecorder\TrackInterface;
+use Ivory\HttpAdapter\HttpAdapterException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Tape subscriber.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class TapeRecorderSubscriber implements EventSubscriberInterface
+{
+    const RECORDING_MODE_ONCE = 1;      // Performs a real request and stores it to a fixture, unless the fixture
+    // already exists.
+    const RECORDING_MODE_OVERWRITE = 2; // Always performs a real request and overwrites the fixture.
+    const RECORDING_MODE_NEVER = 3;     // Always performs a real request and does not write a fixture.
+
+    public static $recordingModes = array(
+        self::RECORDING_MODE_ONCE => 'once',
+        self::RECORDING_MODE_OVERWRITE => 'overwrite',
+        self::RECORDING_MODE_NEVER => 'never'
+    );
+
+    /**
+     * @var bool
+     */
+    private $isRecording;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * The current tape
+     *
+     * @var Tape
+     */
+    private $currentTape;
+
+    /**
+     * The current recording mode.
+     *
+     * @var int
+     */
+    private $recordingMode;
+
+    /**
+     * Initializes the subscriber.
+     *
+     * @param string $path
+     */
+    public function __construct($path)
+    {
+        // @codeCoverageIgnoreStart
+        if (!class_exists('Symfony\Component\Yaml\Yaml')) {
+            throw new \RuntimeException('You need the symfony/yaml library to use the Tape Recorder subscriber');
+        }
+        // @codeCoverageIgnoreEnd
+
+        $this->path = $path;
+        $this->isRecording = false;
+        $this->recordingMode = self::RECORDING_MODE_ONCE;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            Events::PRE_SEND        => array('onPreSend', 400),
+            Events::POST_SEND       => array('onPostSend', 400),
+            Events::EXCEPTION       => array('onException', 400),
+        );
+    }
+
+    /**
+     * Sets the recording mode.
+     *
+     * @param int $recordingMode The recording mode.
+     *
+     * @return void No return value.
+     */
+    public function setRecordingMode($recordingMode)
+    {
+        if (!array_key_exists($recordingMode, self::$recordingModes)) {
+            throw new \InvalidArgumentException(sprintf('Undefined recording mode %s.', $recordingMode));
+        }
+
+        $this->recordingMode = $recordingMode;
+    }
+
+    /**
+     * Inserts the tape with the given name.
+     *
+     * @param $name string The name.
+     *
+     * @return void No return value.
+     */
+    public function insertTape($name)
+    {
+        if (isset($this->currentTape)) {
+            throw new \OutOfBoundsException("Another tape is already inserted.");
+        }
+
+        $this->currentTape = new Tape($name, $this->path);
+    }
+
+    /**
+     * Ejects the currently inserted tape.
+     *
+     * @return void No return value.
+     *
+     * @codeCoverageIgnore
+     */
+    public function eject()
+    {
+        if (!$this->currentTape) {
+            // Not throwing an exception because no harm is done.
+            return;
+        }
+
+        $this->stopRecording();
+        $this->currentTape->store();
+        unset($this->currentTape);
+    }
+
+    /**
+     * Starts recording.
+     *
+     * @return void No return value.
+     */
+    public function startRecording()
+    {
+        if (!$this->currentTape) {
+            throw new \OutOfBoundsException("No tape has been inserted.");
+        }
+
+        if ($this->recordingMode !== self::RECORDING_MODE_NEVER) {
+            $this->isRecording = true;
+        }
+    }
+
+    /**
+     * Stops recording.
+     *
+     * @return void No return value.
+     *
+     * @codeCoverageIgnore
+     */
+    public function stopRecording()
+    {
+        $this->isRecording = false;
+    }
+
+    /**
+     * On pre send event.
+     *
+     * @param  PreSendEvent                               $event The pre send event.
+     * @throws TapeRecorderException|HttpAdapterException
+     */
+    public function onPreSend(PreSendEvent $event)
+    {
+        if (!$this->isRecording) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if ($this->currentTape->hasTrackForRequest($request)
+            && $this->recordingMode !== self::RECORDING_MODE_OVERWRITE
+        ) {
+            $track = $this->currentTape->getTrackForRequest($request);
+            $request->setParameter('track', $track);
+            $this->currentTape->replay($track);
+        }
+
+        $this->currentTape->startRecording($request);
+    }
+
+    /**
+     * On post send event.
+     *
+     * We reach this event when the request has not been intercepted.
+     *
+     * @param PostSendEvent $event The post send event.
+     */
+    public function onPostSend(PostSendEvent $event)
+    {
+        if (!$this->isRecording) {
+            return;
+        }
+
+        $request = $event->getRequest();
+
+        if (!$request->hasParameter('track')) {
+            // Nothing to do here. Since we are in recording mode, the request should
+            // have a track, but we check nonetheless, it's better to be safe than sorry
+            return;
+        }
+
+        /** @var TrackInterface $track */
+        $track = $request->getParameter('track');
+        $this->currentTape->finishRecording(
+            $track,
+            $event->getResponse(),
+            $event->hasException() ? $event->getException() : null
+        );
+    }
+
+    /**
+     * We arrive here when the request has successfully been intercepted
+     *
+     * @param ExceptionEvent $event The exception event.
+     */
+    public function onException(ExceptionEvent $event)
+    {
+        if (!$this->isRecording) {
+            return;
+        }
+
+        $exception = $event->getException();
+        $request = $exception->getRequest();
+
+        if (!$request->hasParameter('track')) {
+            // Nothing to do here. Since we are in recording mode, the request should
+            // have a track, but we check nonetheless, it's better to be safe than sorry
+            return;
+        }
+
+        /** @var TrackInterface $track */
+        $track = $request->getParameter('track');
+
+        if (!($exception instanceof TapeRecorderException)) {
+            // Normal exception, let's store it in the track for the next time
+            $this->currentTape->finishRecording(
+                $track,
+                $event->getResponse(),
+                $event->getException()
+            );
+
+            return;
+        }
+
+        // We are in replay mode
+        if ($track->hasResponse()) {
+            $event->setResponse($track->getResponse());
+        }
+
+        if ($track->hasException()) {
+            $event->setException($track->getException());
+        }
+    }
+}

--- a/src/Event/TapeRecorder/Converter.php
+++ b/src/Event/TapeRecorder/Converter.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * This file is part of the ivory-http-adapter package.
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\InternalRequestInterface;
+use Ivory\HttpAdapter\Message\MessageFactory;
+use Ivory\HttpAdapter\Message\MessageFactoryInterface;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+class Converter
+{
+    /**
+     * @var MessageFactoryInterface
+     */
+    private $messageFactory;
+
+    public function __construct(MessageFactoryInterface $messageFactory = null)
+    {
+        $this->messageFactory = $messageFactory ?: new MessageFactory();
+    }
+
+    /**
+     * @param TrackInterface $track
+     * @return array
+     */
+    public function trackToArray(TrackInterface $track)
+    {
+        $t = clone $track;
+
+        $data = array(
+            'request' => $this->requestToArray($t->getRequest())
+        );
+
+        if ($t->hasResponse()) {
+            $data['response'] = $this->responseToArray($t->getResponse());
+        }
+
+        if ($t->hasException()) {
+            $data['exception'] = $this->exceptionToArray($t->getException());
+        }
+
+        return $data;
+    }
+
+    /**
+     * @param array $data
+     * @return TrackInterface
+     */
+    public function arrayToTrack(array $data)
+    {
+        $track = new Track($this->arrayToRequest($data['request']));
+
+        if (isset($data['response'])) {
+            $track->setResponse($this->arrayToResponse($data['response']));
+        }
+
+        if (isset($data['exception'])) {
+            $track->setException($this->arrayToException($data['exception']));
+        }
+
+        return $track;
+    }
+
+    /**
+     * @param InternalRequestInterface $request
+     * @return array
+     */
+    public function internalRequestToArray(InternalRequestInterface $request)
+    {
+        $r = $this->messageFactory->cloneInternalRequest($request);
+        $r->removeParameter('track');
+
+        return array(
+            'url'              => (string) $request->getUrl(),
+            'method'           => $request->getMethod(),
+            'protocol_version' => $request->getProtocolVersion(),
+            'headers'          => $request->getHeaders(),
+            'raw_datas'        => $request->getRawDatas(),
+            'datas'            => $request->getDatas(),
+            'files'            => $request->getFiles(),
+            'parameters'       => $request->getParameters(),
+        );
+    }
+
+    /**
+     * @param array $data
+     * @return InternalRequestInterface
+     */
+    public function arrayToInternalRequest(array $data)
+    {
+        return $this->messageFactory->createInternalRequest(
+            $data['url'],
+            $data['method'],
+            $data['protocol_version'],
+            $data['headers'],
+            $data['datas'],
+            $data['files'],
+            $data['parameters']
+        );
+    }
+
+    /**
+     * @param RequestInterface|InternalRequestInterface $request
+     * @return array
+     */
+    public function requestToArray(RequestInterface $request)
+    {
+        $r = $this->messageFactory->cloneRequest($request);
+        $r->removeParameter('track');
+
+        $body = null;
+        if ($request instanceof InternalRequestInterface) {
+            $body = $request->getRawDatas();
+        } elseif ($request->hasBody()) {
+            $body = (string) $request->getBody();
+        }
+
+        return array(
+            'url'              => (string) $r->getUrl(),
+            'method'           => $r->getMethod(),
+            'protocol_version' => $r->getProtocolVersion(),
+            'headers'          => $r->getHeaders(),
+            'body'             => $body,
+            'parameters'       => $r->getParameters(),
+        );
+    }
+
+    /**
+     * @param array $data
+     * @return RequestInterface
+     */
+    public function arrayToRequest(array $data)
+    {
+        return $this->messageFactory->createRequest(
+            $data['url'],
+            $data['method'],
+            $data['protocol_version'],
+            $data['headers'],
+            isset($data['body']) ? $data['body'] : null,
+            $data['parameters']
+        );
+    }
+
+    /**
+     * Gets an array from a Response.
+     *
+     * @param ResponseInterface $response
+     * @return array
+     */
+    public function responseToArray(ResponseInterface $response)
+    {
+        $r = $this->messageFactory->cloneResponse($response);
+
+        return array(
+            'status_code'      => $r->getStatusCode(),
+            'reason_phrase'    => $r->getReasonPhrase(),
+            'protocol_version' => $r->getProtocolVersion(),
+            'headers'          => $r->getHeaders(),
+            'body'             => (string) $r->getBody(),
+            'parameters'       => $r->getParameters(),
+        );
+    }
+
+    /**
+     * Gets a response from an array.
+     *
+     * @param array $data
+     * @return ResponseInterface
+     */
+    public function arrayToResponse(array $data)
+    {
+        return $this->messageFactory->createResponse(
+            $data['status_code'],
+            $data['reason_phrase'],
+            $data['protocol_version'],
+            $data['headers'],
+            $data['body'],
+            $data['parameters']
+        );
+    }
+
+    /**
+     * Gets an array from an HttpAdapterException.
+     *
+     * @param HttpAdapterException $exception
+     * @return array
+     */
+    public function exceptionToArray(HttpAdapterException $exception)
+    {
+        $array = array(
+            'code'    => $exception->getCode(),
+            'message' => $exception->getMessage(),
+        );
+
+        if ($exception->hasRequest()) {
+            $array['request'] = $this->internalRequestToArray($exception->getRequest());
+        }
+
+        if ($exception->hasResponse()) {
+            $array['response'] = $this->responseToArray($exception->getResponse());
+        }
+
+        return $array;
+    }
+
+    /**
+     * Gets an HttpAdapterException from an array.
+     *
+     * @param array $data
+     * @return HttpAdapterException
+     */
+    public function arrayToException(array $data)
+    {
+        $exception = new HttpAdapterException($data['message'], $data['code']);
+
+        if (isset($data['request'])) {
+            $exception->setRequest($this->arrayToInternalRequest($data['request']));
+        }
+
+        if (isset($data['response'])) {
+            $exception->setResponse($this->arrayToResponse($data['response']));
+        }
+
+        return $exception;
+    }
+}

--- a/src/Event/TapeRecorder/Tape.php
+++ b/src/Event/TapeRecorder/Tape.php
@@ -1,0 +1,235 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Tape
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class Tape implements TapeInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var TrackMatcher
+     */
+    private $trackMatcher;
+
+    /**
+     * @var TrackInterface[]
+     */
+    private $tracks;
+
+    /**
+     * @var string
+     */
+    private $storagePath;
+
+    /**
+     * @var Converter
+     */
+    private $converter;
+
+    /**
+     * Initializes a tape with the given name and loads already existing tracks from the file storage.
+     *
+     * @param string $name        The name of the tap.
+     * @param string $storagePath The path where the tape is stored.
+     */
+    public function __construct($name, $storagePath)
+    {
+        $this->name = $name;
+        $this->storagePath = $storagePath;
+
+        $this->trackMatcher = new TrackMatcher();
+        $this->converter = new Converter();
+        $this->load();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getStoragePath()
+    {
+        if (!file_exists($this->storagePath)) {
+            mkdir($this->storagePath, 0777, true);
+        }
+
+        return $this->storagePath;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function startRecording(RequestInterface $request)
+    {
+        $track = new Track($request);
+        $request->setParameter('track', $track);
+
+        $this->writeTrack($track);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replay(TrackInterface $track)
+    {
+        if ($track->hasException()) {
+            $this->replayException($track); // throws an HttpAdapterException
+        }
+
+        if ($track->hasResponse()) {
+            $this->replayResponse($track); // throws a TapeRecorderException
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function finishRecording(
+        TrackInterface $track,
+        ResponseInterface $response = null,
+        HttpAdapterException $exception = null
+    ) {
+        $track->setResponse($response);
+        $track->setException($exception);
+
+        $this->writeTrack($track);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replayException(TrackInterface $track)
+    {
+        throw $track->getException();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function replayResponse(TrackInterface $track)
+    {
+        $e = TapeRecorderException::interceptingRequest();
+        $e->setResponse($track->getResponse());
+        throw $e;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function writeTrack(TrackInterface $track)
+    {
+        $newTracks = array();
+
+        foreach ($this->tracks as $key => $existing) {
+            if (!$this->trackMatcher->matchByRequest($existing, $track->getRequest())) {
+                $newTracks[] = $existing;
+            }
+        }
+
+        $newTracks[] = $track;
+
+        $this->tracks = $newTracks;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTracks()
+    {
+        return $this->tracks;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function load()
+    {
+        $this->tracks = array();
+
+        $filePath = $this->getFilePath();
+
+        if (is_file($filePath) && is_readable($filePath)) {
+            $data = Yaml::parse($filePath);
+            foreach ($data as $item) {
+                $this->writeTrack($this->converter->arrayToTrack($item));
+            }
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function store()
+    {
+        $filePath = $this->getFilePath();
+        $data = array();
+        foreach ($this->tracks as $track) {
+            $data[] = $this->converter->trackToArray($track);
+        }
+
+        file_put_contents($filePath, Yaml::dump($data, 4));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasTrackForRequest(RequestInterface $request)
+    {
+        foreach ($this->tracks as $track) {
+            if ($this->trackMatcher->matchByRequest($track, $request)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getTrackForRequest(RequestInterface $request)
+    {
+        foreach ($this->tracks as $track) {
+            if ($this->trackMatcher->matchByRequest($track, $request)) {
+                return $track;
+            }
+        }
+
+        return new Track($request);
+    }
+
+    /**
+     * Returns a file path for the current tape.
+     *
+     * @return string
+     */
+    private function getFilePath()
+    {
+        return $this->getStoragePath().DIRECTORY_SEPARATOR.$this->getName().'.yml';
+    }
+}

--- a/src/Event/TapeRecorder/TapeInterface.php
+++ b/src/Event/TapeRecorder/TapeInterface.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+/**
+ * Tape.
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+interface TapeInterface
+{
+    /**
+     * Gets the name of the tape.
+     *
+     * @return string
+     */
+    public function getName();
+
+    /**
+     * Starts recording.
+     *
+     * @param RequestInterface $request The request.
+     *
+     * @return void No return value.
+     */
+    public function startRecording(RequestInterface $request);
+
+    /**
+     * Replays a track, if it has either a response or an exception.
+     *
+     * @param TrackInterface $track The track to replay.
+     *
+     * @throws HttpAdapterException  When an exception is replayed.
+     * @throws TapeRecorderException When a response is replayed.
+     *
+     * @return void No return value.
+     */
+    public function replay(TrackInterface $track);
+
+    /**
+     * Writes the track to the tape.
+     *
+     * @param TrackInterface            $track     The track to write.
+     * @param ResponseInterface|null    $response  The response to write into the track.
+     * @param HttpAdapterException|null $exception The exception to write into the track.
+     *
+     * @return void No return value.
+     */
+    public function finishRecording(
+        TrackInterface $track,
+        ResponseInterface $response = null,
+        HttpAdapterException $exception = null
+    );
+
+    /**
+     * Replays the exception of the given track.
+     *
+     * @param TrackInterface $track The track.
+     *
+     * @throws HttpAdapterException The exception to be replayed
+     *
+     * @return void No return value.
+     */
+    public function replayException(TrackInterface $track);
+
+    /**
+     * Replays the response of the given track.
+     *
+     * This is done by throwing a TapeRecorderException, which will trigger the exception event of the
+     * TapeRecorderSubscriber.
+     *
+     * @param TrackInterface $track The track.
+     *
+     * @throws TapeRecorderException The Tape Recorder exception.
+     *
+     * @return void No return value.
+     */
+    public function replayResponse(TrackInterface $track);
+
+    /**
+     * (Over)Writes a track to the current tape.
+     *
+     * @param TrackInterface $track
+     */
+    public function writeTrack(TrackInterface $track);
+
+    /**
+     * Checks whether a track exists for the given request.
+     *
+     * @param RequestInterface $request The request.
+     *
+     * @return bool TRUE if a track exists, FALSE if not.
+     */
+    public function hasTrackForRequest(RequestInterface $request);
+
+    /**
+     * Returns a track for the given request. If a track does not already exist, creates a new one.
+     *
+     * @param RequestInterface $request The request.
+     *
+     * @return TrackInterface The (new) track.
+     */
+    public function getTrackForRequest(RequestInterface $request);
+
+    /**
+     * Returns the tracks.
+     *
+     * @return TrackInterface[] The tracks.
+     */
+    public function getTracks();
+
+    /**
+     * Loads already existing tracks into the tape.
+     *
+     * @return void No return value.
+     */
+    public function load();
+
+    /**
+     * Stores the tape.
+     *
+     * @return void No return value.
+     */
+    public function store();
+}

--- a/src/Event/TapeRecorder/TapeRecorderException.php
+++ b/src/Event/TapeRecorder/TapeRecorderException.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\HttpAdapterException;
+
+/**
+ * TapeRecorder Exception
+ *
+ * A special type of exception which can be used to intercept a request and set the request's
+ * response and exception with recorded values
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class TapeRecorderException extends HttpAdapterException
+{
+    /**
+     * @return TapeRecorderException
+     */
+    public static function interceptingRequest()
+    {
+        return new static("Intercepting request.");
+    }
+}

--- a/src/Event/TapeRecorder/Track.php
+++ b/src/Event/TapeRecorder/Track.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+/**
+ * Track
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class Track implements TrackInterface
+{
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * @var HttpAdapterException
+     */
+    private $exception;
+
+    public function __construct(RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasResponse()
+    {
+        return $this->response !== null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResponse()
+    {
+        if (!$this->hasResponse()) {
+            return null;
+        }
+
+        if ($this->response->hasBody()) {
+            $this->response->getBody()->seek(0, SEEK_SET);
+        }
+
+        return $this->response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setResponse(ResponseInterface $response = null)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hasException()
+    {
+        return $this->exception !== null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getException()
+    {
+        if (!$this->hasException()) {
+            return null;
+        }
+
+        if ($this->exception->hasResponse() && $this->exception->getResponse()->hasBody()) {
+            $this->exception->getResponse()->getBody()->seek(0, SEEK_SET);
+        }
+
+        return $this->exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setException(HttpAdapterException $exception = null)
+    {
+        $this->exception = $exception;
+    }
+}

--- a/src/Event/TapeRecorder/TrackInterface.php
+++ b/src/Event/TapeRecorder/TrackInterface.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+/**
+ * Track
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+interface TrackInterface
+{
+    /**
+     * Gets the request.
+     *
+     * @return RequestInterface The request.
+     */
+    public function getRequest();
+
+    /**
+     * Whether the track has a response or not.
+     *
+     * @return bool
+     */
+    public function hasResponse();
+
+    /**
+     * Gets the response.
+     *
+     * @return ResponseInterface The response.
+     */
+    public function getResponse();
+
+    /**
+     * Sets the response.
+     *
+     * @param ResponseInterface $response The response.
+     *
+     * @return void No return value.
+     */
+    public function setResponse(ResponseInterface $response = null);
+
+    /**
+     * Whether the track has an exception or not.
+     *
+     * @return bool
+     */
+    public function hasException();
+
+    /**
+     * Gets the exception.
+     *
+     * @return HttpAdapterException The exception.
+     */
+    public function getException();
+
+    /**
+     * Sets the exception.
+     *
+     * @param HttpAdapterException|null $exception The exception.
+     *
+     * @return void No return value.
+     */
+    public function setException(HttpAdapterException $exception = null);
+}

--- a/src/Event/TapeRecorder/TrackMatcher.php
+++ b/src/Event/TapeRecorder/TrackMatcher.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\Message\RequestInterface;
+
+/**
+ * Track matcher
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class TrackMatcher
+{
+    /**
+     * The formatter.
+     *
+     * @var Converter
+     */
+    private $converter;
+
+    /**
+     * Initializes the matcher.
+     */
+    public function __construct()
+    {
+        $this->converter = new Converter();
+    }
+
+    /**
+     * Returns TRUE when the given Track's request matches the given request
+     *
+     * @param TrackInterface           $track   The track.
+     * @param RequestInterface $request The request.
+     *
+     * @return bool TRUE if the Track's request matches the given request, FALSE if not.
+     */
+    public function matchByRequest(TrackInterface $track, RequestInterface $request)
+    {
+        $trackRequestData = $this->converter->requestToArray($track->getRequest());
+        $requestData = $this->converter->requestToArray($request);
+
+        // If the diff is empty, this means that all keys from the Track request are available in the array
+        // from the other request, so they can be considered equal.
+        $diff = $this->array_diff_assoc_recursive($requestData, $trackRequestData);
+        $isEqual = empty($diff);
+
+        return $isEqual;
+    }
+
+    /**
+     * Recursively computes the difference between two arrays.
+     *
+     * This is needed to compare two requests, because an HTTP Adapter implementation can change the request during
+     * the execution of the doSendInternalRequest() method.
+     *
+     * @link http://php.net/manual/en/function.array-diff-assoc.php#111675 Reference implementation
+     * @codeCoverageIgnore
+     *
+     * @param  array $a
+     * @param  array $b
+     * @return array
+     */
+    private function array_diff_assoc_recursive(array $a, array $b)
+    {
+        $difference = array();
+        foreach ($a as $key => $value) {
+            if (is_array($value)) {
+                if (!isset($b[$key]) || !is_array($b[$key])) {
+                    $difference[$key] = $value;
+                } else {
+                    $new_diff = $this->array_diff_assoc_recursive($value, $b[$key]);
+                    if (!empty($new_diff)) {
+                        $difference[$key] = $new_diff;
+                    }
+                }
+            } elseif (!array_key_exists($key, $b) || $b[$key] !== $value) {
+                $difference[$key] = $value;
+            }
+        }
+
+        return $difference;
+    }
+}

--- a/tests/Event/Subscriber/TapeRecorderSubscriberTest.php
+++ b/tests/Event/Subscriber/TapeRecorderSubscriberTest.php
@@ -1,0 +1,569 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\Subscriber;
+
+use Ivory\HttpAdapter\Event\Events;
+use Ivory\HttpAdapter\Event\ExceptionEvent;
+use Ivory\HttpAdapter\Event\PostSendEvent;
+use Ivory\HttpAdapter\Event\PreSendEvent;
+use Ivory\HttpAdapter\Event\Subscriber\TapeRecorderSubscriber;
+use Ivory\HttpAdapter\Event\TapeRecorder\Tape;
+use Ivory\HttpAdapter\Event\TapeRecorder\TapeRecorderException;
+use Ivory\HttpAdapter\Event\TapeRecorder\TrackInterface;
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\InternalRequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+
+/**
+ * Tape Recorder subscriber test.
+ *
+ * @group TapeRecorderSubscriber
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class TapeRecorderSubscriberTest extends AbstractSubscriberTest
+{
+    /**
+     * @var TapeRecorderSubscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->subscriber = new TapeRecorderSubscriber(
+            $this->path = sys_get_temp_dir().'/TapeRecorderSubscriber'
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->subscriber);
+    }
+
+    public function testSubscribedEvents()
+    {
+        $events = TapeRecorderSubscriber::getSubscribedEvents();
+
+        $this->assertArrayHasKey(Events::PRE_SEND, $events);
+        $this->assertSame(array('onPreSend', 400), $events[Events::PRE_SEND]);
+
+        $this->assertArrayHasKey(Events::POST_SEND, $events);
+        $this->assertSame(array('onPostSend', 400), $events[Events::POST_SEND]);
+
+        $this->assertArrayHasKey(Events::EXCEPTION, $events);
+        $this->assertSame(array('onException', 400), $events[Events::EXCEPTION]);
+    }
+
+    public function testInitialState()
+    {
+        $this->assertAttributeSame($this->path, 'path', $this->subscriber);
+        $this->assertAttributeEquals(false, 'isRecording', $this->subscriber);
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     */
+    public function testInsertingTwoTapesShouldThrowAnException()
+    {
+        $this->subscriber->insertTape('foo');
+        $this->subscriber->insertTape('foo');
+    }
+
+    public function testEject()
+    {
+        $this->subscriber->eject();
+        $this->assertAttributeEquals(false, 'isRecording', $this->subscriber);
+        $this->assertAttributeEquals(null, 'currentTape', $this->subscriber);
+    }
+
+    public function testStartRecording()
+    {
+        $this->injectTapeMock();
+        $this->subscriber->startRecording();
+        $this->assertAttributeEquals(true, 'isRecording', $this->subscriber);
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     */
+    public function testStartRecordingWithoutATapeShouldThrowAnException()
+    {
+        $this->subscriber->startRecording();
+    }
+
+    public function testStopRecording()
+    {
+        $this->subscriber->stopRecording();
+        $this->assertAttributeEquals(false, 'isRecording', $this->subscriber);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Undefined recording mode -1.
+     */
+    public function testSettingAnInvalidRecordingModeShouldThrowException()
+    {
+        $this->subscriber->setRecordingMode(-1);
+    }
+
+    public function testSettingRecordingModeToNeverShouldNeverStartRecording()
+    {
+        $preSendEvent = $this->createPreSendEventMock();
+        $preSendEvent
+            ->expects($this->never())
+            ->method('getRequest');
+
+        $postSendEvent = $this->createPostSendEventMock();
+        $postSendEvent
+            ->expects($this->never())
+            ->method('getRequest');
+
+        $exceptionEvent = $this->createExceptionEventMock();
+        $exceptionEvent
+            ->expects($this->never())
+            ->method('getException');
+
+        $this->injectTapeMock();
+        $this->subscriber->setRecordingMode(TapeRecorderSubscriber::RECORDING_MODE_NEVER);
+
+        $this->subscriber->startRecording();
+        $this->assertAttributeEquals(false, 'isRecording', $this->subscriber);
+
+        $this->subscriber->onPreSend($preSendEvent);
+        $this->subscriber->onPostSend($postSendEvent);
+        $this->subscriber->onException($exceptionEvent);
+    }
+
+    public function testSettingRecordingModeToOverwriteShouldNeverReplay()
+    {
+        $tape = $this->createTapeMock();
+
+        $tape
+            ->expects($this->once())
+            ->method('hasTrackForRequest')
+            ->with($request = $this->createRequestMock())
+            ->willReturn(true)
+        ;
+
+        $tape
+            ->expects($this->never())
+            ->method('replay')
+        ;
+
+        $this->injectTapeMock($tape);
+        $this->subscriber->setRecordingMode(TapeRecorderSubscriber::RECORDING_MODE_OVERWRITE);
+        $this->subscriber->startRecording();
+        $this->subscriber->onPreSend($this->createPreSendEvent(null, $request));
+    }
+
+    public function testPreSendEventWithEmptyTapeShouldStartRecording()
+    {
+        $tape = $this->createTapeMock();
+
+        $tape
+            ->expects($this->once())
+            ->method('hasTrackForRequest')
+            ->with($request = $this->createRequestMock())
+            ->willReturn(false)
+        ;
+
+        $tape
+            ->expects($this->never())
+            ->method('getTrackForRequest')
+        ;
+
+        $tape
+            ->expects($this->once())
+            ->method('startRecording')
+            ->with($request)
+        ;
+
+        $this->injectTapeMock($tape);
+
+        $this->subscriber->startRecording();
+        $this->subscriber->onPreSend($this->createPreSendEvent(null, $request));
+    }
+
+    public function testPreSendEventWithExistingTrackShouldReplay()
+    {
+        $tape = $this->createTapeMock();
+
+        $tape
+            ->expects($this->once())
+            ->method('hasTrackForRequest')
+            ->with($request = $this->createRequestMock())
+            ->willReturn(true)
+        ;
+
+        $tape
+            ->expects($this->once())
+            ->method('getTrackForRequest')
+            ->with($request)
+            ->willReturn($track = $this->createTrackMock($request))
+        ;
+
+        $tape
+            ->expects($this->once())
+            ->method('replay')
+            ->with($track)
+        ;
+
+        $this->injectTapeMock($tape);
+
+        $this->subscriber->startRecording();
+        $this->subscriber->onPreSend($this->createPreSendEvent(null, $request));
+    }
+
+    public function testPreSendEventWithoutStartedRecordingShouldDoNothing()
+    {
+        $tape = $this->createTapeMock();
+        $tape
+            ->expects($this->never())
+            ->method('startRecording')
+        ;
+
+        $this->subscriber->onPreSend($this->createPreSendEvent(null, $this->createRequestMock()));
+    }
+
+    public function testPostSendEventWithoutStartedRecordingShouldDoNothing()
+    {
+        $tape = $this->createTapeMock();
+        $tape
+            ->expects($this->never())
+            ->method('startRecording')
+        ;
+
+        $this->subscriber->onPostSend($this->createPostSendEvent(null, $this->createRequestMock()));
+    }
+
+    public function testPostSend()
+    {
+        $request = $this->createRequestMock();
+        $request
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('track')
+            ->willReturn(true);
+
+        $request
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('track')
+            ->willReturn($track = $this->createTrackMock($request));
+
+        $this->injectTapeMock($tape = $this->createTapeMock());
+
+        $tape
+            ->expects($this->once())
+            ->method('finishRecording');
+
+        $this->subscriber->startRecording();
+        $this->subscriber->onPostSend($this->createPostSendEvent(null, $request));
+    }
+
+    public function testPostSendEventWithARequestThatHasNoAttachedTrackShouldDoNothing()
+    {
+        $this->injectTapeMock($tape = $this->createTapeMock());
+        $tape
+            ->expects($this->never())
+            ->method('finishRecording');
+
+        $request = $this->createRequestMock();
+        $request
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('track')
+            ->willReturn(false);
+
+        $this->subscriber->startRecording();
+        $this->subscriber->onPostSend($this->createPostSendEvent(null, $request));
+    }
+
+    public function testExceptionEventWithoutStartedRecordingShouldDoNothing()
+    {
+        $event = $this->createExceptionEvent(null, $exception = $this->createExceptionMock());
+        $exception
+            ->expects($this->never())
+            ->method('hasRequest');
+
+        $this->subscriber->onException($event);
+    }
+
+    public function testExceptionEventWithARequestThatHasNoAttachedTrackShouldDoNothing()
+    {
+        $exception = $this->createExceptionMock($request = $this->createRequestMock());
+        $request
+            ->expects($this->once())
+            ->method('hasParameter')
+            ->with('track')
+            ->willReturn(false);
+
+        $request
+            ->expects($this->never())
+            ->method('getParameter');
+
+        $this->injectTapeMock();
+        $this->subscriber->startRecording();
+        $this->subscriber->onException($this->createExceptionEvent(null, $exception));
+    }
+
+    public function testExceptionEventWithNormalHttpAdapterExceptionShouldFinishRecording()
+    {
+        $exception = $this->createExceptionMock(
+            $request = $this->createRequestMockWithTrack(
+                $track = $this->createTrackMock()
+            )
+        );
+
+        $track
+            ->expects($this->never())
+            ->method('hasResponse');
+
+        $this->injectTapeMock($tape = $this->createTapeMock());
+        $tape
+            ->expects($this->once())
+            ->method('finishRecording');
+
+        $this->subscriber->startRecording();
+        $this->subscriber->onException($this->createExceptionEvent(null, $exception));
+    }
+
+    public function testExceptionEventWithFullTrackWillReplayTheResponseAndException()
+    {
+        $track = $this->createTrackMock(
+            $this->createRequestMock(),
+            $response = $this->createResponseMock(),
+            $exception = $this->createExceptionMock()
+        );
+
+        $exception = $this->createTapeRecorderExceptionMock(
+            $request = $this->createRequestMockWithTrack($track), $response, $exception
+        );
+
+        $this->injectTapeMock($tape = $this->createTapeMock());
+
+        $tape
+            ->expects($this->never())
+            ->method('finishRecording');
+
+        $event = $this->createExceptionEvent(null, $exception);
+
+        $this->subscriber->startRecording();
+        $this->subscriber->onException($event);
+    }
+
+    private function injectTapeMock($tape = null)
+    {
+        $tape = $tape ?: $this->createTapeMock();
+
+        $r = new \ReflectionClass($this->subscriber);
+        $p = $r->getProperty('currentTape');
+        $p->setAccessible(true);
+        $p->setValue($this->subscriber, $tape);
+    }
+
+    /**
+     * @return Tape|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createTapeMock()
+    {
+        return $this
+            ->getMockBuilder('Ivory\HttpAdapter\Event\TapeRecorder\TapeInterface')
+            ->getMock();
+    }
+
+    /**
+     * @param  InternalRequestInterface                                $request
+     * @param  ResponseInterface                                       $response
+     * @param  HttpAdapterException                                    $exception
+     * @return TrackInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createTrackMock(
+        InternalRequestInterface $request = null,
+        ResponseInterface $response = null,
+        HttpAdapterException $exception = null
+    ) {
+        $request = $request ?: $this->createRequestMock();
+
+        $track = $this
+            ->getMockBuilder('Ivory\HttpAdapter\Event\TapeRecorder\TrackInterface')
+            ->getMock();
+
+        $track->expects($this->any())
+            ->method('hasRequest')
+            ->willReturn(true);
+
+        $track->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($request);
+
+        $track->expects($this->any())
+            ->method('getResponse')
+            ->willReturn($response);
+
+        $track->expects($this->any())
+            ->method('hasResponse')
+            ->willReturn($response ? true : false);
+
+        $track->expects($this->any())
+            ->method('getException')
+            ->willReturn($exception);
+
+        $track->expects($this->any())
+            ->method('hasException')
+            ->willReturn($exception ? true : false);
+
+        return $track;
+    }
+
+    /**
+     * @param  TrackInterface                                                    $track
+     * @return InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createRequestMockWithTrack(TrackInterface $track = null)
+    {
+        $request = $this->createRequestMock();
+
+        $request
+            ->expects($this->any())
+            ->method('hasParameter')
+            ->with('track')
+            ->willReturn(true);
+
+        $request
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with('track')
+            ->willReturn($track);
+
+        return $request;
+    }
+
+    /**
+     * @param  InternalRequestInterface                                       $internalRequest
+     * @param  ResponseInterface                                              $response
+     * @param  HttpAdapterException                                           $httpAdapterException
+     * @return TapeRecorderException|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createTapeRecorderExceptionMock(
+        InternalRequestInterface $internalRequest = null,
+        ResponseInterface $response = null,
+        HttpAdapterException $httpAdapterException = null
+    ) {
+        $exception = $this->getMock('Ivory\HttpAdapter\Event\TapeRecorder\TapeRecorderException');
+
+        if ($internalRequest === null) {
+            $internalRequest = $this->createRequestMock();
+        }
+
+        $exception
+            ->expects($this->any())
+            ->method('hasRequest')
+            ->will($this->returnValue(true));
+
+        $exception
+            ->expects($this->any())
+            ->method('getRequest')
+            ->will($this->returnValue($internalRequest));
+
+        if ($response) {
+            $exception
+                ->expects($this->any())
+                ->method('hasResponse')
+                ->will($this->returnValue(true));
+
+            $exception
+                ->expects($this->any())
+                ->method('getResponse')
+                ->will($this->returnValue($response));
+        } else {
+            $exception
+                ->expects($this->any())
+                ->method('hasResponse')
+                ->will($this->returnValue(false));
+
+            $exception
+                ->expects($this->never())
+                ->method('getResponse');
+        }
+
+        if ($httpAdapterException) {
+            $exception
+                ->expects($this->any())
+                ->method('hasException')
+                ->will($this->returnValue(true));
+
+            $exception
+                ->expects($this->any())
+                ->method('getException')
+                ->will($this->returnValue($httpAdapterException));
+        } else {
+            $exception
+                ->expects($this->any())
+                ->method('hasException')
+                ->will($this->returnValue(false));
+
+            $exception
+                ->expects($this->never())
+                ->method('getException');
+        }
+
+        return $exception;
+    }
+
+    /**
+     * @return PreSendEvent|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createPreSendEventMock()
+    {
+        $event = $this->getMockBuilder('Ivory\HttpAdapter\Event\PreSendEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $event;
+    }
+
+    /**
+     * @return PostSendEvent|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createPostSendEventMock()
+    {
+        $event = $this->getMockBuilder('Ivory\HttpAdapter\Event\PostSendEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $event;
+    }
+
+    /**
+     * @return ExceptionEvent|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createExceptionEventMock()
+    {
+        $event = $this->getMockBuilder('Ivory\HttpAdapter\Event\ExceptionEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        return $event;
+    }
+}

--- a/tests/Event/TapeRecorder/TapeTest.php
+++ b/tests/Event/TapeRecorder/TapeTest.php
@@ -1,0 +1,329 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\CurlHttpAdapter;
+use Ivory\HttpAdapter\Event\TapeRecorder\Tape;
+use Ivory\HttpAdapter\Event\TapeRecorder\TapeRecorderException;
+use Ivory\HttpAdapter\Event\TapeRecorder\Track;
+use Ivory\HttpAdapter\Event\TapeRecorder\TrackInterface;
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\MessageFactory;
+use Ivory\HttpAdapter\Message\RequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Ivory\HttpAdapter\Message\Stream\StringStream;
+
+/**
+ * Tape test.
+ *
+ * @group TapeRecorderSubscriber
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class TapeTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    private $storagePath;
+
+    /**
+     * @var MessageFactory
+     */
+    private $messageFactory;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->storagePath = __DIR__.'/fixtures';
+        $this->messageFactory = new MessageFactory();
+    }
+
+    public function testStorageDirGetsCreated()
+    {
+        new Tape('foo', $path = sys_get_temp_dir().'/'.uniqid());
+        $this->assertFileExists($path);
+        @unlink($path);
+    }
+
+    public function testStoreEmptyTape()
+    {
+        $tape = new Tape($name = 'foo', $path = sys_get_temp_dir().'/'.uniqid());
+        $tape->store();
+        $this->assertFileExists($file = sprintf('%s/%s.yml', $path, $name));
+        @unlink($file);
+    }
+
+    public function testStoreTape()
+    {
+        $tape = new Tape($name = 'foo', $path = sys_get_temp_dir().'/'.uniqid());
+
+        $tape->writeTrack($track = $this->createTrack('http://foo.bar'));
+        $tape->store();
+        $this->assertFileExists($file = sprintf('%s/%s.yml', $path, $name));
+
+        // Reload
+        $tape->load();
+        $this->assertCount(1, $tracks = $tape->getTracks());
+        $this->assertEquals($track, $tracks[0]);
+
+        @unlink($file);
+    }
+
+    public function testLoadExistingTape()
+    {
+        // $this->prepareFixtureFile(__FUNCTION__); // Only to be used when changing the TapeTest, uncomment before committing
+
+        $tape = $this->createTape(__FUNCTION__);
+        $this->assertCount(1, $tracks = $tape->getTracks());
+        $track = $tracks[0];
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\TapeRecorder\Track', $track);
+
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\RequestInterface', $track->getRequest());
+
+        $this->assertTrue($track->hasResponse());
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $track->getResponse());
+
+        $this->assertTrue($track->hasException());
+        $this->assertInstanceOf('Ivory\HttpAdapter\HttpAdapterException', $track->getException());
+    }
+
+    public function testEmptyTape()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $this->assertCount(0, $tape->getTracks());
+    }
+
+    public function testStartRecording()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $tape->startRecording($request = $this->createRequest());
+
+        $this->assertTrue($request->hasParameter('track'));
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\TapeRecorder\TrackInterface', $request->getParameter('track'));
+    }
+
+    public function testFinishRecording()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $tape->startRecording($request = $this->createRequest());
+        $track = $request->getParameter('track');
+
+        $tape->finishRecording($track, $response = $this->createResponse(), $exception = $this->createException());
+
+        $this->assertTrue($track->hasResponse());
+        $this->assertSame($response, $track->getResponse());
+
+        $this->assertTrue($track->hasException());
+        $this->assertSame($exception, $track->getException());
+    }
+
+    public function testGetTrackForRequestWithEmptyTape()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $this->assertFalse($tape->hasTrackForRequest($request = $this->createRequest()));
+        $this->assertInstanceOf(
+            'Ivory\HttpAdapter\Event\TapeRecorder\TrackInterface',
+            $tape->getTrackForRequest($request)
+        );
+    }
+
+    public function testGetTrackForRequest()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $track = $this->createTrackMock($request = $this->createRequest());
+        $tape->writeTrack($track);
+
+        $this->assertTrue($tape->hasTrackForRequest($request));
+        $this->assertSame($track, $tape->getTrackForRequest($request));
+    }
+
+    public function testWriteTrack()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $track1 = $this->createTrackMock($this->createRequest());
+        $track2 = $this->createTrackMock($this->createRequest('http://foo.bar'));
+
+        $tape->writeTrack($track1);
+        $tape->writeTrack($track2);
+        $this->assertCount(2, $tracks = $tape->getTracks());
+    }
+
+    public function testWriteTrackTwiceResultsInOneTrackOnly()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $track = $this->createTrackMock($this->createRequest());
+
+        $tape->writeTrack($track);
+        $tape->writeTrack($track);
+        $this->assertCount(1, $tracks = $tape->getTracks());
+        $this->assertSame($track, $tracks[0]);
+    }
+
+    public function testReplayResponseFromExistingTrack()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+        $track = $this->createTrackMock($request = $this->createRequest(), $response = $this->createResponse());
+
+        try {
+            $tape->replay($track);
+            $this->fail('TapeRecorderException excepted, none thrown');
+        } catch (TapeRecorderException $e) {
+            $this->assertSame($response, $e->getResponse());
+        }
+    }
+
+    public function testReplayExceptionFromExistingTrack()
+    {
+        $tape = $this->createTape(__FUNCTION__);
+
+        $track = $this->createTrackMock(
+            $request = $this->createRequest(),
+            $response = $this->createResponse(),
+            $exception = $this->createException()
+        );
+
+        try {
+            $tape->replay($track);
+            $this->fail('HttpAdapterException excepted, none thrown');
+        } catch (HttpAdapterException $e) {
+            $this->assertSame($exception, $e);
+        }
+    }
+
+    protected function createTape($name)
+    {
+        return new Tape($name, $this->storagePath);
+    }
+
+    /**
+     * @param  RequestInterface                                $request
+     * @param  ResponseInterface                                       $response
+     * @param  HttpAdapterException                                    $exception
+     * @return TrackInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function createTrackMock(
+        RequestInterface $request = null,
+        ResponseInterface $response = null,
+        HttpAdapterException $exception = null
+    ) {
+        $request = $request ?: $this->createRequest();
+
+        $track = $this
+            ->getMockBuilder('Ivory\HttpAdapter\Event\TapeRecorder\TrackInterface')
+            ->getMock();
+
+        $track->expects($this->any())
+            ->method('hasRequest')
+            ->willReturn(true);
+
+        $track->expects($this->any())
+            ->method('getRequest')
+            ->willReturn($request);
+
+        $track->expects($this->any())
+            ->method('getResponse')
+            ->willReturn($response);
+
+        $track->expects($this->any())
+            ->method('hasResponse')
+            ->willReturn($response ? true : false);
+
+        $track->expects($this->any())
+            ->method('getException')
+            ->willReturn($exception);
+
+        $track->expects($this->any())
+            ->method('hasException')
+            ->willReturn($exception ? true : false);
+
+        return $track;
+    }
+
+    /**
+     * Creates a track for a request with the given url.
+     *
+     * @param  string $requestUrl
+     * @param  bool   $hasResponse
+     * @param  bool   $hasException
+     * @return Track
+     */
+    protected function createTrack($requestUrl, $hasResponse = true, $hasException = false)
+    {
+        $track = new Track($request = $this->createRequest($requestUrl));
+
+        if ($hasResponse) {
+            $track->setResponse($this->createResponse());
+        }
+
+        if ($hasException) {
+            $track->setException($this->createException());
+        }
+
+        return $track;
+    }
+
+    /**
+     * Creates a request.
+     *
+     * @param  null                     $url
+     * @param  TrackInterface           $track
+     * @return RequestInterface
+     */
+    protected function createRequest($url = null, TrackInterface $track = null)
+    {
+        $request = $this->messageFactory->createRequest($url ?: 'http://egeloen.fr/');
+
+        if ($track) {
+            $request->setParameter('track', $track);
+        }
+
+        return $request;
+    }
+
+    /**
+     * Creates a response.
+     *
+     * @return ResponseInterface
+     */
+    protected function createResponse()
+    {
+        return $this->messageFactory->createResponse(200, 'OK', '1.1', array(), new StringStream(null, 3), array());
+    }
+
+    protected function createException()
+    {
+        return new HttpAdapterException('Some message');
+    }
+
+    private function prepareFixtureFile($methodName)
+    {
+        $tape = $this->createTape($methodName);
+        $httpAdapter = new CurlHttpAdapter();
+        $request = $httpAdapter->getConfiguration()->getMessageFactory()->createRequest('http://httpstat.us/200');
+        $response = $httpAdapter->sendRequest($request);
+        $exception = new HttpAdapterException();
+        $exception->setRequest(
+            $httpAdapter->getConfiguration()->getMessageFactory()->createInternalRequest('http://httpstat.us/200')
+        );
+        $exception->setResponse($response);
+
+        $track = new Track($request);
+        $track->setResponse($response);
+        $track->setException($exception);
+
+        $tape->writeTrack($track);
+        $tape->store();
+    }
+}

--- a/tests/Event/TapeRecorder/TrackTest.php
+++ b/tests/Event/TapeRecorder/TrackTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\TapeRecorder;
+
+use Ivory\HttpAdapter\Event\TapeRecorder\Track;
+use Ivory\HttpAdapter\Message\InternalRequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Ivory\HttpAdapter\HttpAdapterException;
+
+/**
+ * Track test.
+ *
+ * @group TapeRecorderSubscriber
+ *
+ * @author Jérôme Gamez <jerome@gamez.name>
+ */
+class TrackTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Track
+     */
+    private $track;
+
+    /**
+     * @var InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $request;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->track = new Track(
+            $this->request = $this->createRequestMock()
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->track);
+        unset($this->request);
+        unset($this->response);
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertSame($this->request, $this->track->getRequest());
+
+        $this->assertFalse($this->track->hasResponse());
+        $this->assertNull($this->track->getResponse());
+
+        $this->assertFalse($this->track->hasException());
+        $this->assertNull($this->track->getException());
+    }
+
+    public function testSetResponse()
+    {
+        $this->track->setResponse($response = $this->createResponseMock());
+
+        $this->assertTrue($this->track->hasResponse());
+        $this->assertSame($response, $this->track->getResponse());
+    }
+
+    public function testSetException()
+    {
+        $this->track->setException($exception = $this->createExceptionMock());
+
+        $this->assertTrue($this->track->hasException());
+        $this->assertSame($exception, $this->track->getException());
+    }
+
+    /**
+     * Creates a request mock.
+     *
+     * @return InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject The request mock.
+     */
+    private function createRequestMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\InternalRequestInterface');
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createResponseMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+    }
+
+    /**
+     * Creates an exception mock.
+     *
+     * @return HttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createExceptionMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterException');
+    }
+}

--- a/tests/Event/TapeRecorder/fixtures/testLoadExistingTape.yml
+++ b/tests/Event/TapeRecorder/fixtures/testLoadExistingTape.yml
@@ -1,0 +1,44 @@
+-
+    request:
+        url: 'http://httpstat.us/200'
+        method: GET
+        protocol_version: '1.1'
+        headers: {  }
+        body: null
+        parameters: {  }
+    response:
+        status_code: 200
+        reason_phrase: OK
+        protocol_version: '1.1'
+        headers:
+            Cache-Control: [private]
+            Content-Length: ['6']
+            Content-Type: ['text/plain; charset=utf-8']
+            Server: [Microsoft-IIS/8.0]
+            X-AspNetMvc-Version: ['5.1']
+            X-AspNet-Version: [4.0.30319]
+            X-Powered-By: [ASP.NET]
+            Set-Cookie: [ARRAffinity=2e08d880ca1721cfe5157827e382786a839d9f1c5d76ecf6b4a4e420ecdd9950;Path=/;Domain=httpstat.us]
+            Date: ['Tue, 03 Feb 2015 06:41:11 GMT']
+            Connection: [close]
+        body: '200 OK'
+        parameters: {  }
+    exception:
+        code: 0
+        message: ''
+        request:
+            url: 'http://httpstat.us/200'
+            method: GET
+            protocol_version: '1.1'
+            headers: {  }
+            raw_datas: ''
+            datas: {  }
+            files: {  }
+            parameters: {  }
+        response:
+            status_code: 200
+            reason_phrase: OK
+            protocol_version: '1.1'
+            headers: { Cache-Control: [private], Content-Length: ['6'], Content-Type: ['text/plain; charset=utf-8'], Server: [Microsoft-IIS/8.0], X-AspNetMvc-Version: ['5.1'], X-AspNet-Version: [4.0.30319], X-Powered-By: [ASP.NET], Set-Cookie: [ARRAffinity=2e08d880ca1721cfe5157827e382786a839d9f1c5d76ecf6b4a4e420ecdd9950;Path=/;Domain=httpstat.us], Date: ['Tue, 03 Feb 2015 06:41:11 GMT'], Connection: [close] }
+            body: '200 OK'
+            parameters: {  }


### PR DESCRIPTION
This PR adds a Tape Recorder Subscriber, which works similarly to the [php-vcr](http://php-vcr.github.io) and also uses similar wordings :). With it, it is possible to record the HTTP interactions, e.g. in Unit Tests, store them as Fixture files and replay them in future runs.

An example fixture (actually used for such a test) can be found here: [Example fixture](https://github.com/jeromegamez/ivory-http-adapter/blob/feature/tape-recorder-subscriber/tests/Event/TapeRecorder/fixtures/testLoadExistingTape.yml).

[A new section has been added](https://github.com/jeromegamez/ivory-http-adapter/blob/feature/tape-recorder-subscriber/doc/events.md#tape-recorder) to the documentation explaining how to use the subscriber.

### How it works

#### Attaching the subscriber (as usual)

```php
$recorder = new TapeRecorderSubscriber(__DIR__.'/fixtures');
$http->getConfiguration()->getEventDispatcher()->addSubscriber($recorder);
```

#### Inserting a new Tape and start recording
```php
$recorder->insertTape('foo');
$recorder->startRecording();
```

#### Make a request and eject the tape

```php
$http->get('http://httpstat.us/200');
$recorder->eject();
```

If you want to pause recording, you can use `$recorder->stopRecording()` and `$recorder->startRecording()` any time.

Ejecting the tape causes the current tape to be stored in the specified storage path and loaded from there on future runs.

#### First code run
1. **PreSend Event**: A new "Track" gets created and stored as request parameter
2. **PostSend Event**: The response gets stored to the previously created Track.
3. **Exception Event**:  If the sent request triggers a HTTPAdapterException, the exception gets stored into the previously created track.

#### Second code run
1. **PreSend Event**: The recorder finds the previously stored track and replays the recorded result of the interaction by throwing a stored `HttpAdapterException`  or a `TapeRecorderException` - both will be handled in the Exception Event Handler.
2. **Exception Event**: If the thrown exception is a `TapeRecorderException`, the event's response gets overwritten with the response stored in the track.

You can run the tests for this subscriber by specifying the group `TapeRecorderSubscriber`
```bash
$ bin/phpunit --group TapeRecorderSubscriber
```

I appreciate any feedback and suggestions, and would be happy to see this subscriber in the next release of the HTTP Adapter :).

Cheers
:octocat: Jérôme