### PR TITLE
Fix file header PHPDoc

### DIFF
--- a/src/AbstractCurlHttpAdapter.php
+++ b/src/AbstractCurlHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/AbstractHttpAdapter.php
+++ b/src/AbstractHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/AbstractHttpAdapterTemplate.php
+++ b/src/AbstractHttpAdapterTemplate.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/AbstractStreamHttpAdapter.php
+++ b/src/AbstractStreamHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Asset/AbstractUninstantiableAsset.php
+++ b/src/Asset/AbstractUninstantiableAsset.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/BuzzHttpAdapter.php
+++ b/src/BuzzHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/CakeHttpAdapter.php
+++ b/src/CakeHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/ConfigurationInterface.php
+++ b/src/ConfigurationInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/CurlHttpAdapter.php
+++ b/src/CurlHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/BasicAuth/BasicAuth.php
+++ b/src/Event/BasicAuth/BasicAuth.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/BasicAuth/BasicAuthInterface.php
+++ b/src/Event/BasicAuth/BasicAuthInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/Cookie.php
+++ b/src/Event/Cookie/Cookie.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/CookieFactory.php
+++ b/src/Event/Cookie/CookieFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/CookieFactoryInterface.php
+++ b/src/Event/Cookie/CookieFactoryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/CookieInterface.php
+++ b/src/Event/Cookie/CookieInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/Jar/AbstractPersistentCookieJar.php
+++ b/src/Event/Cookie/Jar/AbstractPersistentCookieJar.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/Jar/CookieJar.php
+++ b/src/Event/Cookie/Jar/CookieJar.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/Jar/CookieJarInterface.php
+++ b/src/Event/Cookie/Jar/CookieJarInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/Jar/FileCookieJar.php
+++ b/src/Event/Cookie/Jar/FileCookieJar.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/Jar/PersistentCookieJarInterface.php
+++ b/src/Event/Cookie/Jar/PersistentCookieJarInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Cookie/Jar/SessionCookieJar.php
+++ b/src/Event/Cookie/Jar/SessionCookieJar.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Events.php
+++ b/src/Event/Events.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/ExceptionEvent.php
+++ b/src/Event/ExceptionEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Formatter/Formatter.php
+++ b/src/Event/Formatter/Formatter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Formatter/FormatterInterface.php
+++ b/src/Event/Formatter/FormatterInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/History/Journal.php
+++ b/src/Event/History/Journal.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/History/JournalEntry.php
+++ b/src/Event/History/JournalEntry.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/History/JournalEntryFactory.php
+++ b/src/Event/History/JournalEntryFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/History/JournalEntryFactoryInterface.php
+++ b/src/Event/History/JournalEntryFactoryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/History/JournalEntryInterface.php
+++ b/src/Event/History/JournalEntryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/History/JournalInterface.php
+++ b/src/Event/History/JournalInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/MultiExceptionEvent.php
+++ b/src/Event/MultiExceptionEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/MultiPostSendEvent.php
+++ b/src/Event/MultiPostSendEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/MultiPreSendEvent.php
+++ b/src/Event/MultiPreSendEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/PostSendEvent.php
+++ b/src/Event/PostSendEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/PreSendEvent.php
+++ b/src/Event/PreSendEvent.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Redirect/Redirect.php
+++ b/src/Event/Redirect/Redirect.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Redirect/RedirectInterface.php
+++ b/src/Event/Redirect/RedirectInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Retry.php
+++ b/src/Event/Retry/Retry.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/RetryInterface.php
+++ b/src/Event/Retry/RetryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/AbstractDelayedRetryStrategy.php
+++ b/src/Event/Retry/Strategy/AbstractDelayedRetryStrategy.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/AbstractRetryStrategyChain.php
+++ b/src/Event/Retry/Strategy/AbstractRetryStrategyChain.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/CallbackRetryStrategy.php
+++ b/src/Event/Retry/Strategy/CallbackRetryStrategy.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/ConstantDelayedRetryStrategy.php
+++ b/src/Event/Retry/Strategy/ConstantDelayedRetryStrategy.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/ExponentialDelayedRetryStrategy.php
+++ b/src/Event/Retry/Strategy/ExponentialDelayedRetryStrategy.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/LimitedRetryStrategy.php
+++ b/src/Event/Retry/Strategy/LimitedRetryStrategy.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/LinearDelayedRetryStrategy.php
+++ b/src/Event/Retry/Strategy/LinearDelayedRetryStrategy.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/RetryStrategyChainInterface.php
+++ b/src/Event/Retry/Strategy/RetryStrategyChainInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Retry/Strategy/RetryStrategyInterface.php
+++ b/src/Event/Retry/Strategy/RetryStrategyInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/StatusCode/StatusCode.php
+++ b/src/Event/StatusCode/StatusCode.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/StatusCode/StatusCodeInterface.php
+++ b/src/Event/StatusCode/StatusCodeInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/AbstractFormatterSubscriber.php
+++ b/src/Event/Subscriber/AbstractFormatterSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/AbstractTimerSubscriber.php
+++ b/src/Event/Subscriber/AbstractTimerSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/BasicAuthSubscriber.php
+++ b/src/Event/Subscriber/BasicAuthSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/CookieSubscriber.php
+++ b/src/Event/Subscriber/CookieSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/HistorySubscriber.php
+++ b/src/Event/Subscriber/HistorySubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/LoggerSubscriber.php
+++ b/src/Event/Subscriber/LoggerSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/RedirectSubscriber.php
+++ b/src/Event/Subscriber/RedirectSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/RetrySubscriber.php
+++ b/src/Event/Subscriber/RetrySubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/StatusCodeSubscriber.php
+++ b/src/Event/Subscriber/StatusCodeSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Subscriber/StopwatchSubscriber.php
+++ b/src/Event/Subscriber/StopwatchSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Timer/Timer.php
+++ b/src/Event/Timer/Timer.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Event/Timer/TimerInterface.php
+++ b/src/Event/Timer/TimerInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Extractor/ProtocolVersionExtractor.php
+++ b/src/Extractor/ProtocolVersionExtractor.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Extractor/ReasonPhraseExtractor.php
+++ b/src/Extractor/ReasonPhraseExtractor.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Extractor/StatusCodeExtractor.php
+++ b/src/Extractor/StatusCodeExtractor.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Extractor/StatusLineExtractor.php
+++ b/src/Extractor/StatusLineExtractor.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/FileGetContentsHttpAdapter.php
+++ b/src/FileGetContentsHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/FopenHttpAdapter.php
+++ b/src/FopenHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/GuzzleHttpAdapter.php
+++ b/src/GuzzleHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/GuzzleHttpHttpAdapter.php
+++ b/src/GuzzleHttpHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/HttpAdapterException.php
+++ b/src/HttpAdapterException.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/HttpAdapterFactory.php
+++ b/src/HttpAdapterFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/HttpAdapterInterface.php
+++ b/src/HttpAdapterInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/HttpfulHttpAdapter.php
+++ b/src/HttpfulHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/AbstractMessage.php
+++ b/src/Message/AbstractMessage.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/InternalRequest.php
+++ b/src/Message/InternalRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/InternalRequestInterface.php
+++ b/src/Message/InternalRequestInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/MessageFactoryInterface.php
+++ b/src/Message/MessageFactoryInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/MessageInterface.php
+++ b/src/Message/MessageInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/RequestInterface.php
+++ b/src/Message/RequestInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/ResponseInterface.php
+++ b/src/Message/ResponseInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/Stream/AbstractStream.php
+++ b/src/Message/Stream/AbstractStream.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/Stream/GuzzleHttpStream.php
+++ b/src/Message/Stream/GuzzleHttpStream.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/Stream/GuzzleStream.php
+++ b/src/Message/Stream/GuzzleStream.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/Stream/ResourceStream.php
+++ b/src/Message/Stream/ResourceStream.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Message/Stream/StringStream.php
+++ b/src/Message/Stream/StringStream.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/MultiHttpAdapterException.php
+++ b/src/MultiHttpAdapterException.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Normalizer/BodyNormalizer.php
+++ b/src/Normalizer/BodyNormalizer.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Normalizer/HeadersNormalizer.php
+++ b/src/Normalizer/HeadersNormalizer.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Normalizer/MethodNormalizer.php
+++ b/src/Normalizer/MethodNormalizer.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Normalizer/UrlNormalizer.php
+++ b/src/Normalizer/UrlNormalizer.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Parser/CookieParser.php
+++ b/src/Parser/CookieParser.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Parser/HeadersParser.php
+++ b/src/Parser/HeadersParser.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/ReactHttpAdapter.php
+++ b/src/ReactHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/SocketHttpAdapter.php
+++ b/src/SocketHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/StopwatchHttpAdapter.php
+++ b/src/StopwatchHttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Zend1HttpAdapter.php
+++ b/src/Zend1HttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/src/Zend2HttpAdapter.php
+++ b/src/Zend2HttpAdapter.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/AbstractBuzzHttpAdapterTest.php
+++ b/tests/AbstractBuzzHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/AbstractGuzzleHttpCurlHttpAdapterTest.php
+++ b/tests/AbstractGuzzleHttpCurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/AbstractGuzzleHttpHttpAdapterTest.php
+++ b/tests/AbstractGuzzleHttpHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/AbstractHttpAdapterTest.php
+++ b/tests/AbstractHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/AbstractZend1HttpAdapterTest.php
+++ b/tests/AbstractZend1HttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/AbstractZend2HttpAdapterTest.php
+++ b/tests/AbstractZend2HttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/BuzzCurlHttpAdapterTest.php
+++ b/tests/BuzzCurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/BuzzFileGetContentsHttpAdapterTest.php
+++ b/tests/BuzzFileGetContentsHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/CakeHttpAdapterTest.php
+++ b/tests/CakeHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/CurlHttpAdapterTest.php
+++ b/tests/CurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/DisabledHttpAdapterTest.php
+++ b/tests/DisabledHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/AbstractEventTest.php
+++ b/tests/Event/AbstractEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/BasicAuth/BasicAuthTest.php
+++ b/tests/Event/BasicAuth/BasicAuthTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/CookieFactoryTest.php
+++ b/tests/Event/Cookie/CookieFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/CookieTest.php
+++ b/tests/Event/Cookie/CookieTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/Jar/AbstractCookieJarTest.php
+++ b/tests/Event/Cookie/Jar/AbstractCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/Jar/AbstractPersistentCookieJarTest.php
+++ b/tests/Event/Cookie/Jar/AbstractPersistentCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/Jar/CookieJarTest.php
+++ b/tests/Event/Cookie/Jar/CookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/Jar/FileCookieJarTest.php
+++ b/tests/Event/Cookie/Jar/FileCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/Jar/PersistentCookieJarTest.php
+++ b/tests/Event/Cookie/Jar/PersistentCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Cookie/Jar/SessionCookieJarTest.php
+++ b/tests/Event/Cookie/Jar/SessionCookieJarTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/ExceptionEventTest.php
+++ b/tests/Event/ExceptionEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Formatter/FormatterTest.php
+++ b/tests/Event/Formatter/FormatterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/History/JournalEntryFactoryTest.php
+++ b/tests/Event/History/JournalEntryFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/History/JournalEntryTest.php
+++ b/tests/Event/History/JournalEntryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/History/JournalTest.php
+++ b/tests/Event/History/JournalTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/MultiExceptionEventTest.php
+++ b/tests/Event/MultiExceptionEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/MultiPostSendEventTest.php
+++ b/tests/Event/MultiPostSendEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/MultiPreSendEventTest.php
+++ b/tests/Event/MultiPreSendEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/PostSendEventTest.php
+++ b/tests/Event/PostSendEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/PreSendEventTest.php
+++ b/tests/Event/PreSendEventTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Redirect/RedirectTest.php
+++ b/tests/Event/Redirect/RedirectTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/RetryTest.php
+++ b/tests/Event/Retry/RetryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/AbstractRetryStrategyTest.php
+++ b/tests/Event/Retry/Strategy/AbstractRetryStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/CallbackRetryStrategyTest.php
+++ b/tests/Event/Retry/Strategy/CallbackRetryStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/ConstantDelayedRetryStrategyTest.php
+++ b/tests/Event/Retry/Strategy/ConstantDelayedRetryStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/DelayedRetryStrategyTest.php
+++ b/tests/Event/Retry/Strategy/DelayedRetryStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/ExponentialDelayedRetryStrategyTest.php
+++ b/tests/Event/Retry/Strategy/ExponentialDelayedRetryStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/LimitedRetryStrategyTest.php
+++ b/tests/Event/Retry/Strategy/LimitedRetryStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/LinearDelayedRetryStrategyTest.php
+++ b/tests/Event/Retry/Strategy/LinearDelayedRetryStrategyTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Retry/Strategy/RetryStrategyChainTest.php
+++ b/tests/Event/Retry/Strategy/RetryStrategyChainTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/StatusCode/StatusCodeTest.php
+++ b/tests/Event/StatusCode/StatusCodeTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/AbstractSubscriberTest.php
+++ b/tests/Event/Subscriber/AbstractSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/BasicAuthSubscriberTest.php
+++ b/tests/Event/Subscriber/BasicAuthSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/CookieSubscriberTest.php
+++ b/tests/Event/Subscriber/CookieSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/FormatterSubscriberTest.php
+++ b/tests/Event/Subscriber/FormatterSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/HistorySubscriberTest.php
+++ b/tests/Event/Subscriber/HistorySubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/LoggerSubscriberTest.php
+++ b/tests/Event/Subscriber/LoggerSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/RedirectSubscriberTest.php
+++ b/tests/Event/Subscriber/RedirectSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/RetrySubscriberTest.php
+++ b/tests/Event/Subscriber/RetrySubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/StatusCodeSubscriberTest.php
+++ b/tests/Event/Subscriber/StatusCodeSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/StopwatchSubscriberTest.php
+++ b/tests/Event/Subscriber/StopwatchSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Subscriber/TimerSubscriberTest.php
+++ b/tests/Event/Subscriber/TimerSubscriberTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Event/Timer/TimerTest.php
+++ b/tests/Event/Timer/TimerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Extractor/ProtocolVersionExtractorTest.php
+++ b/tests/Extractor/ProtocolVersionExtractorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Extractor/ReasonPhraseExtractorTest.php
+++ b/tests/Extractor/ReasonPhraseExtractorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Extractor/StatusCodeExtractorTest.php
+++ b/tests/Extractor/StatusCodeExtractorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Extractor/StatusLineExtractorTest.php
+++ b/tests/Extractor/StatusLineExtractorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/FileGetContentsHttpAdapterTest.php
+++ b/tests/FileGetContentsHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Fixtures/server.php
+++ b/tests/Fixtures/server.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/FopenHttpAdapterTest.php
+++ b/tests/FopenHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/GuzzleHttpAdapterTest.php
+++ b/tests/GuzzleHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/GuzzleHttpCurlHttpAdapterTest.php
+++ b/tests/GuzzleHttpCurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/GuzzleHttpMultiCurlHttpAdapterTest.php
+++ b/tests/GuzzleHttpMultiCurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/GuzzleHttpStreamHttpAdapterTest.php
+++ b/tests/GuzzleHttpStreamHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/HttpAdapterExceptionTest.php
+++ b/tests/HttpAdapterExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/HttpAdapterFactoryTest.php
+++ b/tests/HttpAdapterFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/HttpAdapterTest.php
+++ b/tests/HttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/HttpfulHttpAdapterTest.php
+++ b/tests/HttpfulHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/InternalRequestTest.php
+++ b/tests/Message/InternalRequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/MessageFactoryTest.php
+++ b/tests/Message/MessageFactoryTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/MessageTest.php
+++ b/tests/Message/MessageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/RequestTest.php
+++ b/tests/Message/RequestTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/ResponseTest.php
+++ b/tests/Message/ResponseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/Stream/AbstractResourceStreamTest.php
+++ b/tests/Message/Stream/AbstractResourceStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/Stream/AbstractStreamTest.php
+++ b/tests/Message/Stream/AbstractStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/Stream/GuzzleHttpStreamTest.php
+++ b/tests/Message/Stream/GuzzleHttpStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/Stream/GuzzleStreamTest.php
+++ b/tests/Message/Stream/GuzzleStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/Stream/ResourceStreamTest.php
+++ b/tests/Message/Stream/ResourceStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Message/Stream/StringStreamTest.php
+++ b/tests/Message/Stream/StringStreamTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/MultiHttpAdapterExceptionTest.php
+++ b/tests/MultiHttpAdapterExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Normalizer/AbstractUrlNormalizerTest.php
+++ b/tests/Normalizer/AbstractUrlNormalizerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Normalizer/BodyNormalizerTest.php
+++ b/tests/Normalizer/BodyNormalizerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Normalizer/HeadersNormalizerTest.php
+++ b/tests/Normalizer/HeadersNormalizerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Normalizer/MethodNormalizerTest.php
+++ b/tests/Normalizer/MethodNormalizerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Normalizer/UrlNormalizerTest.php
+++ b/tests/Normalizer/UrlNormalizerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Parser/AbstractCookieParserTest.php
+++ b/tests/Parser/AbstractCookieParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Parser/AbstractHeadersParserTest.php
+++ b/tests/Parser/AbstractHeadersParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Parser/CookieParserTest.php
+++ b/tests/Parser/CookieParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Parser/HeadersParserTest.php
+++ b/tests/Parser/HeadersParserTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/ReactHttpAdapterTest.php
+++ b/tests/ReactHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/SocketHttpAdapterTest.php
+++ b/tests/SocketHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/StopwatchHttpAdapterTest.php
+++ b/tests/StopwatchHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Utility/CakeUtility.php
+++ b/tests/Utility/CakeUtility.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Utility/PHPUnitUtility.php
+++ b/tests/Utility/PHPUnitUtility.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Zend1CurlHttpAdapterTest.php
+++ b/tests/Zend1CurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Zend1ProxyHttpAdapterTest.php
+++ b/tests/Zend1ProxyHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Zend1SocketHttpAdapterTest.php
+++ b/tests/Zend1SocketHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Zend2CurlHttpAdapterTest.php
+++ b/tests/Zend2CurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Zend2ProxyHttpAdapterTest.php
+++ b/tests/Zend2ProxyHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>

--- a/tests/Zend2SocketHttpAdapterTest.php
+++ b/tests/Zend2SocketHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-/*
+/**
  * This file is part of the Ivory Http Adapter package.
  *
  * (c) Eric GELOEN <geloen.eric@gmail.com>


### PR DESCRIPTION
Because of a missing asterisk, IDEs (in my case PHPStorm) and [phpDocumentor](http://phpdoc.org) currently don't recognize the file header comments as such, which in the case of phpDocumentor triggers a lot of warnings when generating the API documentation.

### Before

Collapsed | Expanded
------------ | -------------
 ![before_1](https://cloud.githubusercontent.com/assets/67554/6014331/ee676b1e-ab61-11e4-8e15-7c48c1edd8ec.png) | ![before_2](https://cloud.githubusercontent.com/assets/67554/6014330/ee449ca6-ab61-11e4-964c-4364a5fd8e31.png)

### After
Notice the added line above the comment indicating the recognized file comment, the readable string in the collapsed comment and the bold email address.

Collapsed | Expanded
------------ | -------------
![after_1](https://cloud.githubusercontent.com/assets/67554/6014333/f596e22a-ab61-11e4-905e-34d2170895ea.png) | ![after_2](https://cloud.githubusercontent.com/assets/67554/6014334/f5bd0a68-ab61-11e4-8bab-0be75c2fe409.png)


This looks like a huge PR, but it isn't, it's actually just 206 added asterisks :smile: 

Cheers
:octocat: Jérôme