### PR TITLE
Remove parallel callables which are broken

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -83,6 +83,9 @@ if you want to learn more about the `Ivory\HttpAdapter\Message\InternalRequest`,
 
 ## Send multiple requests
 
+The main purpose of this method is performance! Instead of sending requests serially, the library will send them in
+parallel if the sub adapter is able to do it otherwise, it will fallback on a serial implementation.
+
 ``` php
 use Ivory\HttpAdapter\Message\InternalRequest;
 use Ivory\HttpAdapter\Message\Request;
@@ -109,27 +112,3 @@ try {
     $exceptions = $e->getExceptions();
 }
 ```
-
-You can additionaly pass two callables which will be triggered as soon as a request is completed:
-
-``` php
-use Ivory\HttpAdapter\HttpAdapterException;
-use Ivory\HttpAdapter\Message\ResponseInterface;
-use Ivory\HttpAdapter\MultiHttpAdapterException;
-
-$success = function (ResponseInterface $response) {
-    $request = response->getParameter('request');
-};
-
-$error = function (HttpAdapterException $exception) {
-    $request = $exception->getRequest();
-
-    if ($exception->hasResponse()) {
-        $response = $exception->getResponse();
-    }
-};
-
-$responses = $httpAdapter->sendRequests($requests, $success, $error);
-```
-
-The method will not throw an exception if you pass the `error` callable.

--- a/src/HttpAdapterInterface.php
+++ b/src/HttpAdapterInterface.php
@@ -178,15 +178,13 @@ interface HttpAdapterInterface
     /**
      * Sends requests.
      *
-     * @param array         $requests The requests.
-     * @param callable|null $success  The success callable.
-     * @param callable|null $error    The error callable.
+     * @param array $requests The requests.
      *
      * @throws \Ivory\HttpAdapter\MultiHttpAdapterException If an error occured when you don't provide the error callable.
      *
      * @return array $responses The responses.
      */
-    public function sendRequests(array $requests, $success = null, $error = null);
+    public function sendRequests(array $requests);
 
     /**
      * Gets the name.

--- a/tests/AbstractHttpAdapterTest.php
+++ b/tests/AbstractHttpAdapterTest.php
@@ -242,61 +242,18 @@ abstract class AbstractHttpAdapterTest extends \PHPUnit_Framework_TestCase
      */
     public function testSendRequests(array $requests)
     {
-        $responses = array();
-        $exceptions = array();
-
-        $success = function ($response) use (&$responses) {
-            $responses[] = $response;
-        };
-
-        $error = function ($exception) use (&$exceptions) {
-            $exceptions[] = $exception;
-        };
-
-        $this->assertMultiResponses($this->httpAdapter->sendRequests($requests, $success, $error), $requests);
-        $this->assertMultiResponses($responses, $requests);
-        $this->assertEmpty($exceptions);
+        $this->assertMultiResponses($this->httpAdapter->sendRequests($requests), $requests);
     }
 
     /**
      * @dataProvider erroredRequestsProvider
      */
-    public function testSendErroredRequestsWithErrorCallable(array $requests, array $erroredRequests)
+    public function testSendErroredRequests(array $requests, array $erroredRequests)
     {
-        $responses = array();
-        $exceptions = array();
-
-        $success = function ($response) use (&$responses) {
-            $responses[] = $response;
-        };
-
-        $error = function ($exception) use (&$exceptions) {
-            $exceptions[] = $exception;
-        };
-
-        $result = $this->httpAdapter->sendRequests(array_merge($requests, $erroredRequests), $success, $error);
-
-        $this->assertSame($responses, $result);
-        $this->assertMultiResponses($responses, $requests);
-        $this->assertMultiExceptions($exceptions, $erroredRequests);
-    }
-
-    /**
-     * @dataProvider erroredRequestsProvider
-     */
-    public function testSendErroredRequestsWithoutErrorCallable(array $requests, array $erroredRequests)
-    {
-        $responses = array();
-
-        $success = function ($response) use (&$responses) {
-            $responses[] = $response;
-        };
-
         try {
-            $this->httpAdapter->sendRequests(array_merge($requests, $erroredRequests), $success);
+            $this->httpAdapter->sendRequests(array_merge($requests, $erroredRequests));
             $this->fail();
         } catch (MultiHttpAdapterException $e) {
-            $this->assertSame($e->getResponses(), $responses);
             $this->assertMultiResponses($e->getResponses(), $requests);
             $this->assertMultiExceptions($e->getExceptions(), $erroredRequests);
         }


### PR DESCRIPTION
This PR removes the parallel callables because they are broken as explained in #61 

For now as it is a bloker for the 0.6 release, I prefer remove the feature and see later if we can bring it back.