### PR TITLE
Fix package dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.8",
-        "phly/http": "dev-header-case-sensitivity as 0.11.x-dev"
+        "phly/http": "^0.11.2"
     },
     "require-dev": {
         "cakephp/cakephp": "^2.5.7",
@@ -33,10 +33,6 @@
         "zendframework/zend-http": "^2.3.4"
     },
     "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/egeloen/http.git"
-        },
         {
             "type": "vcs",
             "url": "https://github.com/egeloen/phpunit-mock-objects.git"

--- a/tests/Message/InternalRequestTest.php
+++ b/tests/Message/InternalRequestTest.php
@@ -68,6 +68,8 @@ class InternalRequestTest extends \PHPUnit_Framework_TestCase
             $parameters = array('bip' => 'pog')
         );
 
+        $headers['Host'] = array('egeloen.fr');
+
         $this->assertSame($uri, (string) $this->internalRequest->getUri());
         $this->assertSame($method, $this->internalRequest->getMethod());
         $this->assertSame($headers, $this->internalRequest->getHeaders());

--- a/tests/Message/MessageFactoryTest.php
+++ b/tests/Message/MessageFactoryTest.php
@@ -57,7 +57,7 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Ivory\HttpAdapter\Message\Request', $request);
         $this->assertSame($uri, (string) $request->getUri());
         $this->assertSame(RequestInterface::METHOD_GET, $request->getMethod());
-        $this->assertEmpty($request->getHeaders());
+        $this->assertSame(array('Host' => array('egeloen.fr')), $request->getHeaders());
         $this->assertEmpty((string) $request->getBody());
         $this->assertEmpty($request->getParameters());
     }
@@ -72,6 +72,8 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
             $body = $this->getMock('Psr\Http\Message\StreamableInterface'),
             $parameters = array('baz' => 'bat')
         );
+
+        $headers['Host'] = array('egeloen.fr');
 
         $this->assertSame($uri, (string) $request->getUri());
         $this->assertSame($method, $request->getMethod());
@@ -89,7 +91,7 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($uri, (string) $internalRequest->getUri());
         $this->assertSame(RequestInterface::METHOD_GET, $internalRequest->getMethod());
         $this->assertSame(RequestInterface::PROTOCOL_VERSION_1_1, $internalRequest->getProtocolVersion());
-        $this->assertEmpty($internalRequest->getHeaders());
+        $this->assertSame(array('Host' => array('egeloen.fr')), $internalRequest->getHeaders());
         $this->assertEmpty((string) $internalRequest->getBody());
         $this->assertEmpty($internalRequest->getDatas());
         $this->assertEmpty($internalRequest->getFiles());
@@ -107,6 +109,8 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
             $files = array('bot' => 'ban'),
             $parameters = array('bip' => 'pog')
         );
+
+        $headers['Host'] = array('egeloen.fr');
 
         $this->assertSame($uri, (string) $internalRequest->getUri());
         $this->assertSame($method, $internalRequest->getMethod());
@@ -129,6 +133,8 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
             array(),
             $parameters = array('bip' => 'pog')
         );
+
+        $headers['Host'] = array('egeloen.fr');
 
         $this->assertSame($uri, (string) $internalRequest->getUri());
         $this->assertSame($method, $internalRequest->getMethod());
@@ -154,6 +160,8 @@ class MessageFactoryTest extends \PHPUnit_Framework_TestCase
             array(),
             $parameters = array('bip' => 'pog')
         );
+
+        $headers['Host'] = array('egeloen.fr');
 
         $this->assertSame($uri, (string) $internalRequest->getUri());
         $this->assertSame($method, $internalRequest->getMethod());

--- a/tests/Message/RequestTest.php
+++ b/tests/Message/RequestTest.php
@@ -68,6 +68,8 @@ class RequestTest extends \PHPUnit_Framework_TestCase
             $parameters = array('baz' => 'bat')
         );
 
+        $headers['Host'] = array('egeloen.fr');
+
         $this->assertSame($uri, (string) $this->request->getUri());
         $this->assertSame($method, $this->request->getMethod());
         $this->assertSame($headers, $this->request->getHeaders());


### PR DESCRIPTION
After https://github.com/phly/http/pull/44 was merged and you deleted work branch 5 days ago, this package (from 0.7 to master) is not installable due to unresolved dependency. This PR changes required version of phly/http and fixes regression in tests (see https://github.com/phly/http/pull/39).