### PR TITLE
Fix RedirectSubscriber

### DIFF
--- a/src/Event/Redirect/Redirect.php
+++ b/src/Event/Redirect/Redirect.php
@@ -122,11 +122,19 @@ class Redirect implements RedirectInterface
 
         $strict = $response->getStatusCode() === 303 || (!$this->strict && $response->getStatusCode() <= 302);
 
+        $headers = $internalRequest->getHeaders();
+
+        foreach ($headers as $key => $value) {
+            if (strtolower($key) === 'host') {
+                unset($headers[$key]);
+            }
+        }
+
         $redirect = $httpAdapter->getConfiguration()->getMessageFactory()->createInternalRequest(
             $response->getHeader('Location'),
             $strict ? InternalRequestInterface::METHOD_GET : $internalRequest->getMethod(),
             $internalRequest->getProtocolVersion(),
-            $internalRequest->getHeaders(),
+            $headers,
             $strict ? array() : $internalRequest->getDatas(),
             $strict ? array() : $internalRequest->getFiles(),
             $internalRequest->getParameters()


### PR DESCRIPTION
Yet another regression related to https://github.com/phly/http/pull/39.

Right now, RedirectSubscriber is broken. If redirect happens, every new `Request` object has `Host` header from parent request, so when adapter tries to send it, response will again contain redirect.

It ends up with max retries, but content is never downloaded. 