### PR TITLE
[Travis] Use minimum PHP version for lowest deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ after_script:
 
 matrix:
     include:
-        - php: 5.6
+        - php: 5.4
           env: COMPOSER_PREFER_LOWEST=true
         - php: 5.6
           env: ENABLE_CURL=false


### PR DESCRIPTION
This PR fixes #90. Let's see if travis is happy.