### PR TITLE
[Event] Fix redirect subscriber which throws an exception

### DIFF
--- a/src/Event/Redirect/Redirect.php
+++ b/src/Event/Redirect/Redirect.php
@@ -110,11 +110,16 @@ class Redirect implements RedirectInterface
 
         if ($internalRequest->getParameter(self::REDIRECT_COUNT) >= $this->max) {
             if ($this->throwException) {
-                throw HttpAdapterException::maxRedirectsExceeded(
-                    (string) $this->getRootRequest($internalRequest)->getUri(),
+                $rootRequest = $this->getRootRequest($internalRequest);
+                $exception = HttpAdapterException::maxRedirectsExceeded(
+                    (string) $rootRequest->getUri(),
                     $this->max,
                     $httpAdapter->getName()
                 );
+
+                $exception->setRequest($rootRequest);
+
+                throw $exception;
             }
 
             return false;

--- a/tests/Event/Redirect/RedirectTest.php
+++ b/tests/Event/Redirect/RedirectTest.php
@@ -12,6 +12,7 @@
 namespace Ivory\Tests\HttpAdapter\Event\Redirect;
 
 use Ivory\HttpAdapter\Event\Redirect\Redirect;
+use Ivory\HttpAdapter\HttpAdapterException;
 use Ivory\HttpAdapter\Message\InternalRequestInterface;
 use Ivory\HttpAdapter\Message\MessageFactoryInterface;
 
@@ -138,8 +139,6 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider maxRedirectReachedProvider
-     * @expectedException \Ivory\HttpAdapter\HttpAdapterException
-     * @expectedExceptionMessage An error occurred when fetching the URI "http://egeloen.fr" with the adapter "http_adapter" ("Max redirects exceeded (5)")
      */
     public function testCreateRedirectRequestWithMaxRedirectReachedThrowException($redirectCount, $max)
     {
@@ -173,7 +172,17 @@ class RedirectTest extends \PHPUnit_Framework_TestCase
         $this->redirect->setThrowException(true);
         $this->redirect->setMax($max);
 
-        $this->redirect->createRedirectRequest($response, $request, $this->createHttpAdapterMock());
+        try {
+            $this->redirect->createRedirectRequest($response, $request, $this->createHttpAdapterMock());
+            $this->fail();
+        } catch (HttpAdapterException $e) {
+            $this->assertSame(
+                'An error occurred when fetching the URI "http://egeloen.fr" with the adapter "http_adapter" ("Max redirects exceeded (5)").',
+                $e->getMessage()
+            );
+
+            $this->assertSame($rootRequest, $e->getRequest());
+        }
     }
 
     /**


### PR DESCRIPTION
This PR fixes #87 by setting the request on the exception inside the subscriber. Basically, if a subscriber converts a response into an exception, it **must** populate the request in the exception itself in order to inform further subscribers about the related request.