### PR TITLE
[Headers] Automatically add content-type when there are datas

### DIFF
--- a/src/AbstractHttpAdapter.php
+++ b/src/AbstractHttpAdapter.php
@@ -76,6 +76,7 @@ abstract class AbstractHttpAdapter implements HttpAdapterInterface
         }
 
         if (!$internalRequest->hasHeader('Content-Type')) {
+            $rawDatas = (string) $internalRequest->getBody();
             $datas = $internalRequest->getDatas();
             $files = $internalRequest->getFiles();
 
@@ -89,7 +90,7 @@ abstract class AbstractHttpAdapter implements HttpAdapterInterface
                     'Content-Type',
                     ConfigurationInterface::ENCODING_TYPE_FORMDATA.'; boundary='.$this->configuration->getBoundary()
                 );
-            } elseif ($contentType && !empty($datas)) {
+            } elseif ($contentType && (!empty($datas) || !empty($rawDatas))) {
                 $internalRequest = $internalRequest->withHeader(
                     'Content-Type',
                     ConfigurationInterface::ENCODING_TYPE_URLENCODED

--- a/tests/AbstractHttpAdapterTest.php
+++ b/tests/AbstractHttpAdapterTest.php
@@ -171,10 +171,6 @@ abstract class AbstractHttpAdapterTest extends \PHPUnit_Framework_TestCase
             http_build_query($data, null, '&')
         );
 
-        if (!empty($data)) {
-            $this->httpAdapter->getConfiguration()->setEncodingType(ConfigurationInterface::ENCODING_TYPE_URLENCODED);
-        }
-
         $options = array();
         if ($method === Request::METHOD_HEAD) {
             $options['body'] = null;


### PR DESCRIPTION
This PR drops a hack I have introduced a long time ago in the test about the content type header. Basically, if there is no content-type, some requests fail due to this missing header. Most of the http client (including php ones such as fopen, fsockopen, ... ) assumes it to `application/x-www-form-urlencoded`. So, the library does the same now.