### PR TITLE
Rely on PHP built in server instead of Nginx or Apache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+sudo: false
 
 php:
     - 5.4
@@ -6,44 +7,28 @@ php:
     - 5.6
     - 7.0
     - hhvm
-    - hhvm-nightly
 
 env:
     global:
         - TEST_SERVER=http://127.0.0.1:10000/server.php
-        - PHP_FCGI_CHILDREN=10
         - SYMFONY_VERSION=2.3.*
         - COMPOSER_PREFER_LOWEST=false
         - ENABLE_CURL=true
 
-cache:
-    apt: true
-    directories:
-        - vendor
-        - $HOME/.composer/cache
-
 install:
-    - sudo apt-get update
-    - sudo apt-get install apache2 libapache2-mod-fastcgi
-    - sudo a2enmod actions fastcgi alias
-    - if [[ "$TRAVIS_PHP_VERSION" != hhvm* ]]; then sudo cp -f tests/Fixtures/etc/apache-php.conf /etc/apache2/sites-available/default; fi
-    - if [[ "$TRAVIS_PHP_VERSION" = hhvm* ]]; then sudo cp -f tests/Fixtures/etc/apache-hhvm.conf /etc/apache2/sites-available/default; fi
-    - sudo sed -i "s?%SERVER_DIR%?$(pwd)/tests/Fixtures?g" /etc/apache2/sites-available/default
-    - sudo service apache2 restart
-    - if [[ "$TRAVIS_PHP_VERSION" != hhvm* ]]; then printf "\n" | pecl install propro; fi
-    - if [[ "$TRAVIS_PHP_VERSION" != hhvm* ]]; then printf "\n" | pecl install raphf; fi
-    - if [[ "$TRAVIS_PHP_VERSION" != hhvm* ]]; then printf "\n" | pecl install pecl_http; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "7" ]]; then printf "\n" | pecl install propro; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "7" ]]; then printf "\n" | pecl install raphf; fi
+    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]] && [[ "$TRAVIS_PHP_VERSION" != "7" ]]; then printf "\n" | pecl install pecl_http; fi
     - if [[ "$ENABLE_CURL" = false ]]; then mkdir -p ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d; fi
     - if [[ "$ENABLE_CURL" = false ]]; then echo "disable_functions = curl_init" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
     - if [[ "$TRAVIS_PHP_VERSION" = "5.6" ]]; then echo "always_populate_raw_post_data = -1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; fi
-    - if [[ "$TRAVIS_PHP_VERSION" != hhvm* ]]; then php-cgi -b 127.0.0.1:9000 & fi
-    - if [[ "$TRAVIS_PHP_VERSION" = hhvm* ]]; then hhvm --mode server -vServer.Type=fastcgi -vServer.Port=9000 -vServer.FixPathInfo=true & fi
-    - composer self-update
+    - php -S 127.0.0.1:10000 -t tests/Fixtures > /dev/null 2>&1 &
     - composer require symfony/event-dispatcher:${SYMFONY_VERSION} --no-update --dev
+    - if [[ $COMPOSER_PREFER_LOWEST = true ]]; then composer remove guzzlehttp/ringphp --no-update --dev; fi
     - if [[ "$SYMFONY_VERSION" = *dev* ]]; then sed -i "s/\"MIT\"/\"MIT\",\"minimum-stability\":\"dev\"/g" composer.json; fi
     - composer update --prefer-source `if [[ $COMPOSER_PREFER_LOWEST = true ]]; then echo "--prefer-lowest --prefer-stable"; fi`
 
-script: bin/phpunit --coverage-clover clover.xml
+script: bin/phpunit --configuration phpunit.travis.xml --coverage-clover clover.xml
 
 after_script:
     - sed -i "/^disable_functions =.*$/d" ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
@@ -70,7 +55,6 @@ matrix:
     allow_failures:
         - php: 7.0
         - php: hhvm
-        - php: hhvm-nightly
         - env: SYMFONY_VERSION=2.7.*@dev
 
 notifications:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,34 +41,18 @@ When you're on the new branch with the dependencies, code as much as you want an
 it immediately. Before, you will need to add tests and update the doc. For the tests, everything is tested with
 [PHPUnit](http://phpunit.de/) and the doc is in the markdown format under the `doc` directory.
 
-To run the tests, use the following command:
+To execute the tests, use the following command:
 
 ``` bash
 $ bin/phpunit
 ```
 
-This command will only run tests which does not require a real web server. To run the full tests, you will need to
-copy/paste the `phpunit.xml.dist` to `phpunit.xml` and uncomment the `TEST_SERVER` php server variable. Then, you have
-three possibilities:
-
- * Rely on Apache2 (PHP) by using the `tests/Ivory/Tests/HttpAdapter/Fixtures/etc/apache2-php.conf`.
- * Rely on Apache2 (HHVM) by using the `tests/Ivory/Tests/HttpAdapter/Fixtures/etc/apache2-hhvm.conf`.
- * Rely on Nginx (PHP and HHVM) by using the `tests/Ivory/Tests/HttpAdapter/Fixtures/etc/nginx.conf`.
-
-I would recommend you to rely on Apache2 as Nginx does not support TRACE request. When, your web server is configured
-and running, you will need to increase the number of fastcgi child processes (otherwise the main process will crash)
-and then, start it with the following commands:
+This command will only execute unit tests. The library is also shipped with integration tests which require a web 
+server. To execute them, just start the built in PHP web server and execute tests again with the `integration` group:
 
 ``` bash
-$ export PHP_FCGI_CHILDREN=10
-$ php-cgi -b 127.0.0.1:9000 # PHP
-$ hhvm --mode server -vServer.Type=fastcgi -vServer.Port=9000 -vServer.FixPathInfo=true # HHVM
-```
-
-Then, run the tests again:
-
-``` bash
-$ bin/phpunit
+$ php -S 127.0.0.1:10000 -t tests/Fixtures
+$ bin/phpunit --group integration
 ```
 
 When you have fixed the bug, tested it and documented it, you can commit and push it with the following commands:

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,9 @@
     "require-dev": {
         "cakephp/cakephp": "^3.0.3@dev",
         "ext-curl": "*",
-        "guzzle/guzzle": "^3.9.2",
+        "guzzle/guzzle": "^3.9.4@dev",
         "guzzlehttp/guzzle": "^4.1.4|^5.0",
+        "guzzlehttp/ringphp": "^1.0.8@dev",
         "guzzlehttp/streams": "^1.5|^2.0|^3.0",
         "kriswallsmith/buzz": "^0.13",
         "nategood/httpful": "^0.2.17",

--- a/doc/adapters.md
+++ b/doc/adapters.md
@@ -97,7 +97,7 @@ $reactHttpAdapter = new ReactHttpAdapter();
 The React http adapter does not support all features. The limitations are:
 
  * HTTP 1.1 not supported.
- * Timeout not suppoted.
+ * Timeout not supported.
 
 ## Socket
 

--- a/phpunit.travis.xml
+++ b/phpunit.travis.xml
@@ -9,11 +9,6 @@
     <php>
         <server name="TEST_SERVER" value="http://127.0.0.1:10000/server.php" />
     </php>
-    <groups>
-        <exclude>
-            <group>integration</group>
-        </exclude>
-    </groups>
     <filter>
         <whitelist>
             <directory>./src</directory>

--- a/src/BuzzHttpAdapter.php
+++ b/src/BuzzHttpAdapter.php
@@ -90,7 +90,7 @@ class BuzzHttpAdapter extends AbstractCurlHttpAdapter
 
         return $this->getConfiguration()->getMessageFactory()->createResponse(
             $response->getStatusCode(),
-            (string) $response->getProtocolVersion(),
+            sprintf('%.1f', $response->getProtocolVersion()),
             HeadersNormalizer::normalize($response->getHeaders()),
             BodyNormalizer::normalize($response->getContent(), $internalRequest->getMethod())
         );

--- a/src/PeclHttpAdapter.php
+++ b/src/PeclHttpAdapter.php
@@ -57,9 +57,8 @@ class PeclHttpAdapter extends AbstractHttpAdapter
             : \http\Client\Curl\HTTP_VERSION_1_1;
 
         $request->setOptions(array(
-            'protocol'       => $httpVersion,
-            'timeout'        => $this->getConfiguration()->getTimeout(),
-            'connecttimeout' => $this->getConfiguration()->getTimeout(),
+            'protocol' => $httpVersion,
+            'timeout'  => $this->getConfiguration()->getTimeout(),
         ));
 
         try {

--- a/tests/Fixtures/server.php
+++ b/tests/Fixtures/server.php
@@ -23,11 +23,11 @@ $delay = isset($_GET['delay']) ? $_GET['delay'] : 0;
 $redirect = isset($_GET['redirect']) ? $_GET['redirect'] : false;
 
 if ($serverError) {
-    header('HTTP/1.1 500 Internal Server Error', true, 500);
+    header($_SERVER['SERVER_PROTOCOL'].' 500 Internal Server Error', true, 500);
 }
 
 if ($clientError) {
-    header('HTTP/1.1 400 Bad Request', true, 400);
+    header($_SERVER['SERVER_PROTOCOL'].' 400 Bad Request', true, 400);
 }
 
 if ($delay > 0) {
@@ -35,7 +35,7 @@ if ($delay > 0) {
 }
 
 if ($redirect) {
-    header('HTTP/1.1 302 Found', true, 302);
+    header($_SERVER['SERVER_PROTOCOL'].' 302 Found', true, 302);
     header('Location: http://'.$_SERVER['HTTP_HOST'].$_SERVER['SCRIPT_NAME']);
     echo 'Redirect';
 } else {

--- a/tests/ReactHttpAdapterTest.php
+++ b/tests/ReactHttpAdapterTest.php
@@ -12,6 +12,7 @@
 namespace Ivory\Tests\HttpAdapter;
 
 use Ivory\HttpAdapter\Message\MessageInterface;
+use Ivory\HttpAdapter\Message\Request;
 use Ivory\HttpAdapter\ReactHttpAdapter;
 
 /**
@@ -31,6 +32,9 @@ class ReactHttpAdapterTest extends AbstractHttpAdapterTest
         }
 
         parent::setUp();
+
+        // ReactPHP is only compatible with the HTTP 1.0 protocol version.
+        $this->defaultOptions['protocol_version'] = Request::PROTOCOL_VERSION_1_0;
     }
 
     public function testGetName()


### PR DESCRIPTION
This PR switches the webserver from Apache/Nginx to the built in PHP webserver. It should ease the testsuite running.

ping @sagikazarmark @jeromegamez 