### PR TITLE
Rewind stream before setting it

### DIFF
--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -156,10 +156,14 @@ class MessageFactory implements MessageFactoryInterface
     private function createStream($body)
     {
         if ($body instanceof StreamInterface) {
+            $body->rewind();
+
             return $body;
         }
 
         if (is_resource($body)) {
+            rewind($body);
+
             return new Stream($body);
         }
 
@@ -170,6 +174,7 @@ class MessageFactory implements MessageFactoryInterface
         }
 
         $stream->write((string) $body);
+        $stream->rewind();
 
         return $stream;
     }

--- a/tests/AbstractHttpAdapterTest.php
+++ b/tests/AbstractHttpAdapterTest.php
@@ -582,8 +582,10 @@ abstract class AbstractHttpAdapterTest extends \PHPUnit_Framework_TestCase
         }
 
         if ($options['body'] === null) {
+            $this->assertEmpty($response->getBody()->getContents());
             $this->assertEmpty((string) $response->getBody());
         } else {
+            $this->assertContains($options['body'], $response->getBody()->getContents());
             $this->assertContains($options['body'], (string) $response->getBody());
         }
 


### PR DESCRIPTION
This PR fixes #106. Ths issue was the stream was not rewinded before setting it on the response. Then, the `__toString` works because it automatically rewind the stream in `phly/http` but it is not the case for the `getContents` method. Testcase added in order to avoid further regression.