### PR TITLE
Use Zend\Diactoros instead of Phly\Http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.4.8",
-        "phly/http": "^0.12|^0.13"
+        "zendframework/zend-diactoros": "^1.0"
     },
     "require-dev": {
         "cakephp/cakephp": "^3.0.3",

--- a/doc/psr-7.md
+++ b/doc/psr-7.md
@@ -1,11 +1,11 @@
 # PSR-7 (Http)
 
 For http messaging, the library is based on the [PSR-7 Standard](https://github.com/php-fig/fig-standards/blob/master/proposed/http-message.md) 
-by using the [phly/http](https://github.com/phly/http) package.
+by using the [zendframework/zend-diactoros](https://github.com/zendframework/zend-diactoros) package.
 
 ## Factory
 
-The PSR-7 only defines interfaces and phly/http only defines implementation. The library is shipped with a factory 
+The PSR-7 only defines interfaces and zendframework/zend-diactoros only defines implementation. The library is shipped with a factory 
 which ease the creation of requests/responses. As explained in the configuration [doc](/doc/configuration.md#messafe-factory),
 the requests/responses are created through a factory, so, if you want to create any PSR-7 objects, it is recommended 
 to use the following API:
@@ -41,7 +41,7 @@ $response = $messageFactory->createResponse(
 
 ## Message
 
-The message implementation is based on `Phly\Http\MessageTrait` with some features on top of it through the 
+The message implementation is based on `Zend\Diactoros\MessageTrait` with some features on top of it through the 
 `Ivory\HttpAdapter\Message\MessageTrait` such as parameters. Basically, parameters are arbitrary values that you can 
 store in your message. They are mostly used by the event system in order to store additional informations.
 
@@ -57,7 +57,7 @@ $newMessage = $message->withoutParameter($name);
 
 ## Request
 
-The request is based on `Phly\Http\Request` with additionally the Ivory message features. 
+The request is based on `Zend\Diactoros\Request` with additionally the Ivory message features. 
 
 ## Internal Request
 
@@ -97,8 +97,8 @@ $newInternalRequest = $internalRequest->withoutFile('file');
 
 ## Response
 
-The response is based on `Phly\Http\Response` with additionally the Ivory message features. 
+The response is based on `Zend\Diactoros\Response` with additionally the Ivory message features. 
 
 ## Stream
 
-The response is based on `Phly\Http\Stream`.
+The response is based on `Zend\Diactoros\Stream`.

--- a/src/Message/MessageFactory.php
+++ b/src/Message/MessageFactory.php
@@ -12,8 +12,8 @@
 namespace Ivory\HttpAdapter\Message;
 
 use Ivory\HttpAdapter\Normalizer\HeadersNormalizer;
-use Phly\Http\Stream;
-use Phly\Http\Uri;
+use Zend\Diactoros\Stream;
+use Zend\Diactoros\Uri;
 use Psr\Http\Message\StreamInterface;
 
 /**
@@ -23,7 +23,7 @@ use Psr\Http\Message\StreamInterface;
  */
 class MessageFactory implements MessageFactoryInterface
 {
-    /** @var null|\Phly\Http\Uri */
+    /** @var null|\Zend\Diactoros\Uri */
     private $baseUri;
 
     /**

--- a/src/Message/Request.php
+++ b/src/Message/Request.php
@@ -11,14 +11,14 @@
 
 namespace Ivory\HttpAdapter\Message;
 
-use Phly\Http\Request as PhlyRequest;
+use  Zend\Diactoros\Request as DiactorosRequest;
 
 /**
  * Request.
  *
  * @author GeLo <geloen.eric@gmail.com>
  */
-class Request extends PhlyRequest implements RequestInterface
+class Request extends DiactorosRequest implements RequestInterface
 {
     use MessageTrait;
 

--- a/src/Message/Response.php
+++ b/src/Message/Response.php
@@ -11,14 +11,14 @@
 
 namespace Ivory\HttpAdapter\Message;
 
-use Phly\Http\Response as PhlyResponse;
+use Zend\Diactoros\Response as DiactorosResponse;
 
 /**
  * Response.
  *
  * @author GeLo <geloen.eric@gmail.com>
  */
-class Response extends PhlyResponse implements ResponseInterface
+class Response extends DiactorosResponse implements ResponseInterface
 {
     use MessageTrait;
 

--- a/tests/Event/Cookie/Jar/CookieJarTest.php
+++ b/tests/Event/Cookie/Jar/CookieJarTest.php
@@ -13,7 +13,7 @@ namespace Ivory\Tests\HttpAdapter\Event\Cookie\Jar;
 
 use Ivory\HttpAdapter\Event\Cookie\CookieInterface;
 use Ivory\HttpAdapter\Event\Cookie\Jar\CookieJar;
-use Phly\Http\Uri;
+use Zend\Diactoros\Uri;
 
 /**
  * Cookie jar test.


### PR DESCRIPTION
phly/http has be "Abandoned! Or, rather, rebranded!" as of May 21