### PR TITLE
Catch an exception that is able to provide a request

### DIFF
--- a/src/GuzzleHttpHttpAdapter.php
+++ b/src/GuzzleHttpHttpAdapter.php
@@ -15,6 +15,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Event\CompleteEvent;
 use GuzzleHttp\Event\ErrorEvent;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Pool;
 use Ivory\HttpAdapter\Message\InternalRequestInterface;
 use Ivory\HttpAdapter\Normalizer\BodyNormalizer;
@@ -57,7 +58,7 @@ class GuzzleHttpHttpAdapter extends AbstractCurlHttpAdapter
     {
         try {
             $response = $this->client->send($this->createRequest($internalRequest));
-        } catch (\Exception $e) {
+        } catch (RequestException $e) {
             throw HttpAdapterException::cannotFetchUri(
                 $e->getRequest()->getUrl(),
                 $this->getName(),


### PR DESCRIPTION
Unfortunately I was not able to add tests to handle this scenario. There seems to be no unit tests present, and the existing integration tests are not covering this logic (it's hard to follow them).