### PR TITLE
Add caching support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### 0.8.1 (????-??-??)
 
  * b6e4bdf - [Socket] Fix https connection
- 
+
 ### 0.8.0 (2015-08-12)
 
  * 2d8061b - Add guzzle 6 support

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ which defines how http message should be implemented.
  - [Throw exceptions for errored responses](/doc/events.md#status-code)
  - [Retry errored requests](/doc/events.md#retry)
  - [Follow redirects](/doc/events.md#redirect)
+ - [Cache responses and exceptions](/doc/events.md#cache)
  - [Manage cookies](/doc/events.md#cookie)
 
 ## Testing

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "cakephp/cakephp": "^3.0.3",
+        "doctrine/cache": "^1.4",
         "ext-curl": "*",
         "guzzle/guzzle": "^3.9.4@dev",
         "guzzlehttp/guzzle": "^4.1.4|^5.0|^6.0",
@@ -28,6 +29,7 @@
         "react/dns": "^0.4.1",
         "satooshi/php-coveralls": "^0.6",
         "symfony/event-dispatcher": "^2.0",
+        "tedivm/stash": "^0.13",
         "zendframework/zendframework1": ">=1.12.9,<=1.12.14|^1.12.16",
         "zendframework/zend-http": "^2.3.4"
     },
@@ -38,6 +40,7 @@
         }
     ],
     "suggest": {
+        "doctrine/cache": "Allows you to use the cache event subscriber",
         "ext-curl": "Allows you to use the cURL adapter",
         "ext-http": "Allows you to use the PECL adapter",
         "guzzle/guzzle": "Allows you to use the Guzzle 3 adapter",
@@ -48,7 +51,8 @@
         "zendframework/zend-http": "Allows you to use the Zend 2 adapter",
         "psr/log": "Allows you to use the logger event subscriber",
         "symfony/event-dispatcher": "Allows you to use the event lifecycle",
-        "symfony/stopwatch": "Allows you to use the stopwatch http adapter and event subscriber"
+        "symfony/stopwatch": "Allows you to use the stopwatch http adapter and event subscriber",
+        "tedivm/stash": "Allows you to use the cache event subscriber"
     },
     "autoload": {
         "psr-4": { "Ivory\\HttpAdapter\\": "src/" }

--- a/src/Event/Cache/Adapter/CacheAdapterInterface.php
+++ b/src/Event/Cache/Adapter/CacheAdapterInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\Cache\Adapter;
+
+/**
+ * Cache adapter.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+interface CacheAdapterInterface
+{
+    /**
+     * Checks if an entry exists.
+     *
+     * @param string $id The identifier.
+     *
+     * @return boolean TRUE if a entry exists else FALSE.
+     */
+    public function has($id);
+
+    /**
+     * Gets an entry.
+     *
+     * @param string $id The identifier.
+     *
+     * @return mixed The data.
+     */
+    public function get($id);
+
+    /**
+     * Sets an entry.
+     *
+     * @param string $id       The identifier.
+     * @param mixed  $data     The data.
+     * @param int    $lifeTime The lifetime.
+     *
+     * @return boolean TRUE if the entry was saved else FALSE.
+     */
+    public function set($id, $data, $lifeTime = 0);
+
+    /**
+     * Removes an entry.
+     *
+     * @param string $id The identifier.
+     *
+     * @return boolean TRUE if the entry was deleted else FALSE.
+     */
+    public function remove($id);
+}

--- a/src/Event/Cache/Adapter/DoctrineCacheAdapter.php
+++ b/src/Event/Cache/Adapter/DoctrineCacheAdapter.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\Cache\Adapter;
+
+use Doctrine\Common\Cache\Cache;
+
+/**
+ * Doctrine cache adapter.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class DoctrineCacheAdapter implements CacheAdapterInterface
+{
+    /** @var \Doctrine\Common\Cache\Cache */
+    private $cache;
+
+    /**
+     * Creates a doctrine cache.
+     *
+     * @param \Doctrine\Common\Cache\Cache $cache The doctrine cache.
+     */
+    public function __construct(Cache $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return $this->cache->contains($id);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        return $this->has($id) ? $this->cache->fetch($id) : null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($id, $data, $lifeTime = 0)
+    {
+        return $this->cache->save($id, $data, $lifeTime);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($id)
+    {
+        return $this->cache->delete($id);
+    }
+}

--- a/src/Event/Cache/Adapter/StashCacheAdapter.php
+++ b/src/Event/Cache/Adapter/StashCacheAdapter.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\Cache\Adapter;
+
+use Stash\Pool;
+
+/**
+ * Stash cache adapter.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class StashCacheAdapter implements CacheAdapterInterface
+{
+    /** @var \Stash\Pool */
+    private $pool;
+
+    /**
+     * Creates a stash cache.
+     *
+     * @param \Stash\Pool $pool The stash pool.
+     */
+    public function __construct(Pool $pool)
+    {
+        $this->pool = $pool;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function has($id)
+    {
+        return !$this->pool->getItem($id)->isMiss();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function get($id)
+    {
+        return $this->pool->getItem($id)->get();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function set($id, $data, $lifeTime = 0)
+    {
+        $result = $this->pool->getItem($id)->set($data, $lifeTime);
+        $this->pool->flush();
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function remove($id)
+    {
+        $result = $this->pool->getItem($id)->clear();
+        $this->pool->flush();
+
+        return $result;
+    }
+}

--- a/src/Event/Cache/Cache.php
+++ b/src/Event/Cache/Cache.php
@@ -1,0 +1,313 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\Cache;
+
+use Ivory\HttpAdapter\Event\Formatter\Formatter;
+use Ivory\HttpAdapter\Event\Formatter\FormatterInterface;
+use Ivory\HttpAdapter\HttpAdapterException;
+use Ivory\HttpAdapter\Message\InternalRequestInterface;
+use Ivory\HttpAdapter\Message\MessageFactoryInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface;
+
+/**
+ * Cache.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class Cache implements CacheInterface
+{
+    /** @var \Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface */
+    private $adapter;
+
+    /** @var \Ivory\HttpAdapter\Event\Formatter\FormatterInterface */
+    private $formatter;
+
+    /** @var integer|null */
+    private $lifetime;
+
+    /** @var boolean */
+    private $cacheException;
+
+    /**
+     * Creates a cache.
+     *
+     * @param \Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface  $adapter        The adapter.
+     * @param \Ivory\HttpAdapter\Event\Formatter\FormatterInterface|null    $formatter      The formatter.
+     * @param integer|null                                                  $lifetime       The lifetime.
+     * @param boolean                                                       $cacheException TRUE if the exceptions should be cached else FALSE.
+     */
+    public function __construct(
+        CacheAdapterInterface $adapter,
+        FormatterInterface $formatter = null,
+        $lifetime = null,
+        $cacheException = true
+    ) {
+        $this->setAdapter($adapter);
+        $this->setFormatter($formatter ?: new Formatter());
+        $this->setlifetime($lifetime);
+        $this->cacheException($cacheException);
+    }
+
+    /**
+     * Gets the adapter.
+     *
+     * @return \Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface The adapter.
+     */
+    public function getAdapter()
+    {
+        return $this->adapter;
+    }
+
+    /**
+     * Sets the adapter.
+     *
+     * @param \Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface $adapter The adapter.
+     */
+    public function setAdapter(CacheAdapterInterface $adapter)
+    {
+        $this->adapter = $adapter;
+    }
+
+    /**
+     * Gets the formatter.
+     *
+     * @return \Ivory\HttpAdapter\Event\Formatter\FormatterInterface The formatter.
+     */
+    public function getFormatter()
+    {
+        return $this->formatter;
+    }
+
+    /**
+     * Sets the formatter.
+     *
+     * @param \Ivory\HttpAdapter\Event\Formatter\FormatterInterface $formatter The formatter.
+     */
+    public function setFormatter(FormatterInterface $formatter)
+    {
+        $this->formatter = $formatter;
+    }
+
+    /**
+     * Gets the lifetime.
+     *
+     * @return integer|null The life time.
+     */
+    public function getlifetime()
+    {
+        return $this->lifetime;
+    }
+
+    /**
+     * Sets the lifetime.
+     *
+     * @param integer|null $lifetime The life time.
+     */
+    public function setlifetime($lifetime = null)
+    {
+        $this->lifetime = $lifetime;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function cacheException($cacheException = null)
+    {
+        if ($cacheException !== null) {
+            $this->cacheException = $cacheException;
+        }
+
+        return $this->cacheException;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getResponse(InternalRequestInterface $internalRequest, MessageFactoryInterface $messageFactory)
+    {
+        if (!$this->adapter->has($id = $this->getIdentifier($internalRequest, 'response'))) {
+            return;
+        }
+
+        $response = $this->unserializeResponse($this->adapter->get($id), $messageFactory);
+
+        return $response->withParameter('request', $internalRequest);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getException(InternalRequestInterface $internalRequest, MessageFactoryInterface $messageFactory)
+    {
+        if (!$this->cacheException || !$this->adapter->has($id = $this->getIdentifier($internalRequest, 'exception'))) {
+            return;
+        }
+
+        $exception = $this->unserializeException($this->adapter->get($id));
+        $exception->setRequest($internalRequest);
+
+        return $exception;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveResponse(ResponseInterface $response, InternalRequestInterface $internalRequest)
+    {
+        if (!$this->adapter->has($id = $this->getIdentifier($internalRequest, 'response'))) {
+            $this->adapter->set($id, $this->serializeResponse($response), $this->lifetime);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function saveException(HttpAdapterException $exception, InternalRequestInterface $internalRequest)
+    {
+        if ($this->cacheException && !$this->adapter->has($id = $this->getIdentifier($internalRequest, 'exception'))) {
+            $this->adapter->set($id, $this->serializeException($exception), $this->lifetime);
+        }
+    }
+
+    /**
+     * Gets the adapter identifier.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $internalRequest The internal request.
+     * @param string                                              $context         The context.
+     *
+     * @return string The adapter identifier.
+     */
+    private function getIdentifier(InternalRequestInterface $internalRequest, $context)
+    {
+        return sha1($context.$this->serializeInternalRequest($internalRequest));
+    }
+
+    /**
+     * Serializes an internal request.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $internalRequest The internal request.
+     *
+     * @return string The serialized internal request.
+     */
+    private function serializeInternalRequest(InternalRequestInterface $internalRequest)
+    {
+        $formattedInternalRequest = $this->formatter->formatRequest($internalRequest);
+        unset($formattedInternalRequest['parameters']);
+
+        return $this->serialize($formattedInternalRequest);
+    }
+
+    /**
+     * Serializes a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     *
+     * @return string The serialized response.
+     */
+    private function serializeResponse(ResponseInterface $response)
+    {
+        return $this->serialize($this->formatter->formatResponse($response));
+    }
+
+    /**
+     * Serializes an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     *
+     * @return string The serialized exception.
+     */
+    private function serializeException(HttpAdapterException $exception)
+    {
+        return $this->serialize($this->formatter->formatException($exception));
+    }
+
+    /**
+     * Unserializes a response.
+     *
+     * @param string                                             $serialized The cached response.
+     * @param \Ivory\HttpAdapter\Message\MessageFactoryInterface $messageFactory The message factory.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface The response.
+     */
+    private function unserializeResponse($serialized, MessageFactoryInterface $messageFactory)
+    {
+        return $this->createResponse($this->unserialize($serialized), $messageFactory);
+    }
+
+    /**
+     * Unserializes an exception.
+     *
+     * @param string $serialized The cached exception.
+     *s
+     * @return \Ivory\HttpAdapter\HttpAdapterException The exception.
+     */
+    private function unserializeException($serialized)
+    {
+        return $this->createException($this->unserialize($serialized));
+    }
+
+    /**
+     * Creates a response.
+     *
+     * @param array                                              $unserialized   The unserialized response.
+     * @param \Ivory\HttpAdapter\Message\MessageFactoryInterface $messageFactory The message factory.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface The response.
+     */
+    private function createResponse(array $unserialized, MessageFactoryInterface $messageFactory)
+    {
+        return $messageFactory->createResponse(
+            $unserialized['status_code'],
+            $unserialized['protocol_version'],
+            $unserialized['headers'],
+            $unserialized['body'],
+            $unserialized['parameters']
+        );
+    }
+
+    /**
+     * Creates an exception.
+     *
+     * @param array $unserialized The unserialized exception.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException The exception.
+     */
+    private function createException(array $unserialized)
+    {
+        return new HttpAdapterException($unserialized['message']);
+    }
+
+    /**
+     * Serializes data.
+     *
+     * @param array $data The data.
+     *
+     * @return string The serialized data.
+     */
+    private function serialize(array $data)
+    {
+        return json_encode($data);
+    }
+
+    /**
+     * Unserializes data.
+     *
+     * @param string $data The serialized data.
+     *
+     * @return array The unserialized data.
+     */
+    private function unserialize($data)
+    {
+        return json_decode($data, true);
+    }
+}

--- a/src/Event/Cache/CacheInterface.php
+++ b/src/Event/Cache/CacheInterface.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\Cache;
+
+use Ivory\HttpAdapter\Message\InternalRequestInterface;
+use Ivory\HttpAdapter\Message\MessageFactoryInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
+use Ivory\HttpAdapter\HttpAdapterException;
+
+/**
+ * Cache.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+interface CacheInterface
+{
+    /**
+     * Gets a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $internalRequest
+     * @param \Ivory\HttpAdapter\Message\MessageFactoryInterface  $messageFactory
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|null
+     */
+    public function getResponse(InternalRequestInterface $internalRequest, MessageFactoryInterface $messageFactory);
+
+    /**
+     * Gets an exception.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $internalRequest
+     * @param \Ivory\HttpAdapter\Message\MessageFactoryInterface  $messageFactory
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException|null
+     */
+    public function getException(InternalRequestInterface $internalRequest, MessageFactoryInterface $messageFactory);
+
+    /**
+     * Saves a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface        $response
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $internalRequest
+     */
+    public function saveResponse(ResponseInterface $response, InternalRequestInterface $internalRequest);
+
+    /**
+     * Saves an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException             $exception
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $internalRequest
+     */
+    public function saveException(HttpAdapterException $exception, InternalRequestInterface $internalRequest);
+}

--- a/src/Event/Formatter/Formatter.php
+++ b/src/Event/Formatter/Formatter.php
@@ -27,16 +27,16 @@ class Formatter implements FormatterInterface
      */
     public function formatRequest(InternalRequestInterface $request)
     {
-        return array(
+        return [
             'protocol_version' => $request->getProtocolVersion(),
             'uri'              => (string) $request->getUri(),
             'method'           => $request->getMethod(),
             'headers'          => $request->getHeaders(),
-            'body'             => (string) $request->getBody(),
+            'body'             => utf8_encode((string) $request->getBody()),
             'datas'            => $request->getDatas(),
             'files'            => $request->getFiles(),
-            'parameters'       => $request->getParameters(),
-        );
+            'parameters'       => $this->filterParameters($request->getParameters()),
+        ];
     }
 
     /**
@@ -44,14 +44,14 @@ class Formatter implements FormatterInterface
      */
     public function formatResponse(ResponseInterface $response)
     {
-        return array(
+        return [
             'protocol_version' => $response->getProtocolVersion(),
             'status_code'      => $response->getStatusCode(),
             'reason_phrase'    => $response->getReasonPhrase(),
             'headers'          => $response->getHeaders(),
-            'body'             => (string) $response->getBody(),
-            'parameters'       => $response->getParameters(),
-        );
+            'body'             => utf8_encode((string) $response->getBody()),
+            'parameters'       => $this->filterParameters($response->getParameters()),
+        ];
     }
 
     /**
@@ -59,11 +59,25 @@ class Formatter implements FormatterInterface
      */
     public function formatException(HttpAdapterException $exception)
     {
-        return array(
+        return [
             'code'    => $exception->getCode(),
             'message' => $exception->getMessage(),
             'line'    => $exception->getLine(),
             'file'    => $exception->getFile(),
-        );
+        ];
+    }
+
+    /**
+     * Filters the parameters.
+     *
+     * @param array $parameters The parameters.
+     *
+     * @return array The filtered parameters.
+     */
+    private function filterParameters(array $parameters)
+    {
+        return array_filter($parameters, function ($parameter) {
+            return !is_object($parameter) && !is_resource($parameter);
+        });
     }
 }

--- a/src/Event/MultiRequestCreatedEvent.php
+++ b/src/Event/MultiRequestCreatedEvent.php
@@ -11,8 +11,10 @@
 
 namespace Ivory\HttpAdapter\Event;
 
+use Ivory\HttpAdapter\HttpAdapterException;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 use Ivory\HttpAdapter\Message\InternalRequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
 
 /**
  * Multi request created event.
@@ -21,8 +23,14 @@ use Ivory\HttpAdapter\Message\InternalRequestInterface;
  */
 class MultiRequestCreatedEvent extends AbstractEvent
 {
-    /** @var array */
+    /** @var \Ivory\HttpAdapter\Message\InternalRequestInterface[] */
     private $requests;
+
+    /** @var \Ivory\HttpAdapter\Message\ResponseInterface[] */
+    private $responses = [];
+
+    /** @var \Ivory\HttpAdapter\HttpAdapterException[] */
+    private $exceptions = [];
 
     /**
      * Creates a multi request created event.
@@ -42,7 +50,7 @@ class MultiRequestCreatedEvent extends AbstractEvent
      */
     public function clearRequests()
     {
-        $this->requests = array();
+        $this->requests = [];
     }
 
     /**
@@ -58,7 +66,7 @@ class MultiRequestCreatedEvent extends AbstractEvent
     /**
      * Gets the requests.
      *
-     * @return array The requests.
+     * @return \Ivory\HttpAdapter\Message\InternalRequestInterface[] The requests.
      */
     public function getRequests()
     {
@@ -68,7 +76,7 @@ class MultiRequestCreatedEvent extends AbstractEvent
     /**
      * Sets the requests.
      *
-     * @param array $requests The requests.
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface[] $requests The requests.
      */
     public function setRequests(array $requests)
     {
@@ -79,7 +87,7 @@ class MultiRequestCreatedEvent extends AbstractEvent
     /**
      * Adds the requests.
      *
-     * @param array $requests The requests.
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface[] $requests The requests.
      */
     public function addRequests(array $requests)
     {
@@ -91,7 +99,7 @@ class MultiRequestCreatedEvent extends AbstractEvent
     /**
      * Removes the requests.
      *
-     * @param array $requests The requests.
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface[] $requests The requests.
      */
     public function removeRequests(array $requests)
     {
@@ -131,5 +139,197 @@ class MultiRequestCreatedEvent extends AbstractEvent
     {
         unset($this->requests[array_search($request, $this->requests, true)]);
         $this->requests = array_values($this->requests);
+    }
+
+    /**
+     * Clears the responses.
+     */
+    public function clearResponses()
+    {
+        $this->responses = [];
+    }
+
+    /**
+     * Checks if there are responses.
+     *
+     * @return boolean TRUE if there are responses else FALSE.
+     */
+    public function hasResponses()
+    {
+        return !empty($this->responses);
+    }
+
+    /**
+     * Gets the responses.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface[] The responses.
+     */
+    public function getResponses()
+    {
+        return $this->responses;
+    }
+
+    /**
+     * Sets the responses.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface[] $responses The responses.
+     */
+    public function setResponses(array $responses)
+    {
+        $this->clearResponses();
+        $this->addResponses($responses);
+    }
+
+    /**
+     * Adds the responses.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface[] $responses The responses.
+     */
+    public function addResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->addResponse($response);
+        }
+    }
+
+    /**
+     * Removes the responses.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface[] $responses The responses.
+     */
+    public function removeResponses(array $responses)
+    {
+        foreach ($responses as $response) {
+            $this->removeResponse($response);
+        }
+    }
+
+    /**
+     * Checks if there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     *
+     * @return boolean TRUE if there is the response else FALSE.
+     */
+    public function hasResponse(ResponseInterface $response)
+    {
+        return array_search($response, $this->responses, true) !== false;
+    }
+
+    /**
+     * Adds a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function addResponse(ResponseInterface $response)
+    {
+        $this->responses[] = $response;
+    }
+
+    /**
+     * Removes a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    public function removeResponse(ResponseInterface $response)
+    {
+        unset($this->responses[array_search($response, $this->responses, true)]);
+        $this->responses = array_values($this->responses);
+    }
+
+    /**
+     * Clears the exceptions.
+     */
+    public function clearExceptions()
+    {
+        $this->exceptions = [];
+    }
+
+    /**
+     * Checks if there are exceptions.
+     *
+     * @return boolean TRUE if there are exceptions else FALSE.
+     */
+    public function hasExceptions()
+    {
+        return !empty($this->exceptions);
+    }
+
+    /**
+     * Gets the exceptions.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException[] The exceptions.
+     */
+    public function getExceptions()
+    {
+        return $this->exceptions;
+    }
+
+    /**
+     * Sets the exceptions.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException[] $exceptions The exceptions.
+     */
+    public function setExceptions(array $exceptions)
+    {
+        $this->clearExceptions();
+        $this->addExceptions($exceptions);
+    }
+
+    /**
+     * Adds the exceptions.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException[] $exceptions The exceptions.
+     */
+    public function addExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->addException($exception);
+        }
+    }
+
+    /**
+     * Removes the exceptions.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException[] $exceptions The exceptions.
+     */
+    public function removeExceptions(array $exceptions)
+    {
+        foreach ($exceptions as $exception) {
+            $this->removeException($exception);
+        }
+    }
+
+    /**
+     * Checks if there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     *
+     * @return boolean TRUE if there is the exception else FALSE.
+     */
+    public function hasException(HttpAdapterException $exception)
+    {
+        return array_search($exception, $this->exceptions, true) !== false;
+    }
+
+    /**
+     * Adds an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception
+     */
+    public function addException(HttpAdapterException $exception)
+    {
+        $this->exceptions[] = $exception;
+    }
+
+    /**
+     * Removes an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    public function removeException(HttpAdapterException $exception)
+    {
+        unset($this->exceptions[array_search($exception, $this->exceptions, true)]);
+        $this->exceptions = array_values($this->exceptions);
     }
 }

--- a/src/Event/RequestCreatedEvent.php
+++ b/src/Event/RequestCreatedEvent.php
@@ -11,8 +11,10 @@
 
 namespace Ivory\HttpAdapter\Event;
 
+use Ivory\HttpAdapter\HttpAdapterException;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 use Ivory\HttpAdapter\Message\InternalRequestInterface;
+use Ivory\HttpAdapter\Message\ResponseInterface;
 
 /**
  * Request created event.
@@ -23,6 +25,12 @@ class RequestCreatedEvent extends AbstractEvent
 {
     /** @var \Ivory\HttpAdapter\Message\InternalRequestInterface */
     private $request;
+
+    /** @var \Ivory\HttpAdapter\Message\ResponseInterface|null */
+    private $response;
+
+    /** @var \Ivory\HttpAdapter\HttpAdapterException|null */
+    private $exception;
 
     /**
      * Creates a request created event.
@@ -55,5 +63,65 @@ class RequestCreatedEvent extends AbstractEvent
     public function setRequest(InternalRequestInterface $request)
     {
         $this->request = $request;
+    }
+
+    /**
+     * Checks if there is a response.
+     *
+     * @return boolean TRUE if there is a response else FALSE.
+     */
+    public function hasResponse()
+    {
+        return $this->response !== null;
+    }
+
+    /**
+     * Gets the response.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|null
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Sets the response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface|null $response
+     */
+    public function setResponse(ResponseInterface $response = null)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * Checks if there is an exception.
+     *
+     * @return boolean TRUE if there is an exception else FALSE.
+     */
+    public function hasException()
+    {
+        return $this->exception !== null;
+    }
+
+    /**
+     * Gets the exception.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException|null
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+
+    /**
+     * Sets the exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException|null $exception
+     */
+    public function setException(HttpAdapterException $exception = null)
+    {
+        $this->exception = $exception;
     }
 }

--- a/src/Event/RequestSentEvent.php
+++ b/src/Event/RequestSentEvent.php
@@ -11,19 +11,22 @@
 
 namespace Ivory\HttpAdapter\Event;
 
+use Ivory\HttpAdapter\HttpAdapterException;
 use Ivory\HttpAdapter\HttpAdapterInterface;
 use Ivory\HttpAdapter\Message\InternalRequestInterface;
 use Ivory\HttpAdapter\Message\ResponseInterface;
-use Ivory\HttpAdapter\HttpAdapterException;
 
 /**
  * Request sent event.
  *
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RequestSentEvent extends RequestCreatedEvent
+class RequestSentEvent extends AbstractEvent
 {
-    /** @var \Ivory\HttpAdapter\Message\ResponseInterface */
+    /** @var \Ivory\HttpAdapter\Message\InternalRequestInterface */
+    private $request;
+
+    /** @var \Ivory\HttpAdapter\Message\ResponseInterface|null */
     private $response;
 
     /** @var \Ivory\HttpAdapter\HttpAdapterException|null */
@@ -41,15 +44,36 @@ class RequestSentEvent extends RequestCreatedEvent
         InternalRequestInterface $request,
         ResponseInterface $response
     ) {
-        parent::__construct($httpAdapter, $request);
+        parent::__construct($httpAdapter);
 
+        $this->setRequest($request);
         $this->setResponse($response);
+    }
+
+    /**
+     * Gets the request.
+     *
+     * @return \Ivory\HttpAdapter\Message\InternalRequestInterface The request.
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Sets the request.
+     *
+     * @param \Ivory\HttpAdapter\Message\InternalRequestInterface $request The request.
+     */
+    public function setRequest(InternalRequestInterface $request)
+    {
+        $this->request = $request;
     }
 
     /**
      * Gets the response.
      *
-     * @return \Ivory\HttpAdapter\Message\ResponseInterface The response.
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|null
      */
     public function getResponse()
     {
@@ -59,9 +83,9 @@ class RequestSentEvent extends RequestCreatedEvent
     /**
      * Sets the response.
      *
-     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface|null $response
      */
-    public function setResponse(ResponseInterface $response)
+    public function setResponse(ResponseInterface $response = null)
     {
         $this->response = $response;
     }
@@ -69,7 +93,7 @@ class RequestSentEvent extends RequestCreatedEvent
     /**
      * Checks if there is an exception.
      *
-     * @return boolean TRUE if there is an exception.
+     * @return boolean TRUE if there is an exception else FALSE.
      */
     public function hasException()
     {
@@ -79,7 +103,7 @@ class RequestSentEvent extends RequestCreatedEvent
     /**
      * Gets the exception.
      *
-     * @return \Ivory\HttpAdapter\HttpAdapterException|null The exception.
+     * @return \Ivory\HttpAdapter\HttpAdapterException|null
      */
     public function getException()
     {
@@ -89,7 +113,7 @@ class RequestSentEvent extends RequestCreatedEvent
     /**
      * Sets the exception.
      *
-     * @param \Ivory\HttpAdapter\HttpAdapterException|null $exception The exception.
+     * @param \Ivory\HttpAdapter\HttpAdapterException|null $exception
      */
     public function setException(HttpAdapterException $exception = null)
     {

--- a/src/Event/Subscriber/CacheSubscriber.php
+++ b/src/Event/Subscriber/CacheSubscriber.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\HttpAdapter\Event\Subscriber;
+
+use Ivory\HttpAdapter\Event\Cache\CacheInterface;
+use Ivory\HttpAdapter\Event\Events;
+use Ivory\HttpAdapter\Event\MultiRequestCreatedEvent;
+use Ivory\HttpAdapter\Event\MultiRequestErroredEvent;
+use Ivory\HttpAdapter\Event\MultiRequestSentEvent;
+use Ivory\HttpAdapter\Event\RequestCreatedEvent;
+use Ivory\HttpAdapter\Event\RequestErroredEvent;
+use Ivory\HttpAdapter\Event\RequestSentEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Cache subscriber.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class CacheSubscriber implements EventSubscriberInterface
+{
+    /** @var \Ivory\HttpAdapter\Event\Cache\CacheInterface */
+    private $cache;
+
+    /**
+     * Creates a cache subscriber.
+     *
+     * @param \Ivory\HttpAdapter\Event\Cache\CacheInterface $cache The cache
+     */
+    public function __construct(CacheInterface $cache)
+    {
+        $this->setCache($cache);
+    }
+
+    /**
+     * Gets the cache.
+     *
+     * @return \Ivory\HttpAdapter\Event\Cache\CacheInterface The cache.
+     */
+    public function getCache()
+    {
+        return $this->cache;
+    }
+
+    /**
+     * Sets the cache.
+     *
+     * @param \Ivory\HttpAdapter\Event\Cache\CacheInterface $cache The cache.
+     */
+    public function setCache(CacheInterface $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * On request created.
+     *
+     * @param \Ivory\HttpAdapter\Event\RequestCreatedEvent $event
+     */
+    public function onRequestCreated(RequestCreatedEvent $event)
+    {
+        $request = $event->getRequest();
+        $messageFactory = $event->getHttpAdapter()->getConfiguration()->getMessageFactory();
+
+        if (($response = $this->cache->getResponse($request, $messageFactory)) !== null) {
+            $event->setResponse($response);
+        } elseif (($exception = $this->cache->getException($request, $messageFactory)) !== null) {
+            $event->setException($exception);
+        }
+    }
+
+    /**
+     * On request sent.
+     *
+     * @param \Ivory\HttpAdapter\Event\RequestSentEvent $event
+     */
+    public function onRequestSent(RequestSentEvent $event)
+    {
+        $this->cache->saveResponse($event->getResponse(), $event->getRequest());
+    }
+
+    /**
+     * On request errored.
+     *
+     * @param \Ivory\HttpAdapter\Event\RequestErroredEvent $event
+     */
+    public function onRequestErrored(RequestErroredEvent $event)
+    {
+        $this->cache->saveException($event->getException(), $event->getException()->getRequest());
+    }
+
+    /**
+     * On multi request created.
+     *
+     * @param \Ivory\HttpAdapter\Event\MultiRequestCreatedEvent $event
+     */
+    public function onMultiRequestCreated(MultiRequestCreatedEvent $event)
+    {
+        $messageFactory = $event->getHttpAdapter()->getConfiguration()->getMessageFactory();
+
+        foreach ($event->getRequests() as $request) {
+            if (($response = $this->cache->getResponse($request, $messageFactory)) !== null) {
+                $event->addResponse($response);
+                $event->removeRequest($request);
+            } elseif (($exception = $this->cache->getException($request, $messageFactory)) !== null) {
+                $event->addException($exception);
+                $event->removeRequest($request);
+            }
+        }
+    }
+
+    /**
+     * On multi request sent.
+     *
+     * @param \Ivory\HttpAdapter\Event\MultiRequestSentEvent $event
+     */
+    public function onMultiRequestSent(MultiRequestSentEvent $event)
+    {
+        foreach ($event->getResponses() as $response) {
+            $this->cache->saveResponse($response, $response->getParameter('request'));
+        }
+    }
+
+    /**
+     * On multi request errored.
+     *
+     * @param \Ivory\HttpAdapter\Event\MultiRequestErroredEvent $event
+     */
+    public function onMultiRequestErrored(MultiRequestErroredEvent $event)
+    {
+        foreach ($event->getResponses() as $response) {
+            $this->cache->saveResponse($response, $response->getParameter('request'));
+        }
+
+        foreach ($event->getExceptions() as $exception) {
+            $this->cache->saveException($exception, $exception->getRequest());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            Events::REQUEST_CREATED       => ['onRequestCreated', -100],
+            Events::REQUEST_SENT          => ['onRequestSent', -100],
+            Events::REQUEST_ERRORED       => ['onRequestErrored', -100],
+            Events::MULTI_REQUEST_CREATED => ['onMultiRequestCreated', -100],
+            Events::MULTI_REQUEST_SENT    => ['onMultiRequestSent', -100],
+            Events::MULTI_REQUEST_ERRORED => ['onMultiRequestErrored', -100],
+        ];
+    }
+}

--- a/src/Zend1HttpAdapter.php
+++ b/src/Zend1HttpAdapter.php
@@ -53,9 +53,10 @@ class Zend1HttpAdapter extends AbstractHttpAdapter
         $this->client
             ->resetParameters(true)
             ->setConfig(array(
-                'httpversion'  => $internalRequest->getProtocolVersion(),
-                'timeout'      => $this->getConfiguration()->getTimeout(),
-                'maxredirects' => 0,
+                'httpversion'     => $internalRequest->getProtocolVersion(),
+                'timeout'         => $this->getConfiguration()->getTimeout(),
+                'request_timeout' => $this->getConfiguration()->getTimeout(),
+                'maxredirects'    => 0,
             ))
             ->setUri($uri = (string) $internalRequest->getUri())
             ->setMethod($internalRequest->getMethod())

--- a/tests/Event/Cache/Adapter/DoctrineCacheAdapterTest.php
+++ b/tests/Event/Cache/Adapter/DoctrineCacheAdapterTest.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\Cache\Adapter;
+
+use Ivory\HttpAdapter\Event\Cache\Adapter\DoctrineCacheAdapter;
+
+/**
+ * Doctrine cache adapter test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class DoctrineCacheAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Ivory\HttpAdapter\Event\Cache\Adapter\DoctrineCacheAdapter */
+    private $doctrineCacheAdapter;
+
+    /** @var \Doctrine\Common\Cache\Cache|\PHPUnit_Framework_MockObject_MockObject */
+    private $cache;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->cache = $this->createCacheMock();
+        $this->doctrineCacheAdapter = new DoctrineCacheAdapter($this->cache);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->cache);
+        unset($this->doctrineCacheAdapter);
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertInstanceOf(
+            'Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface',
+            $this->doctrineCacheAdapter
+        );
+    }
+
+    public function testHas()
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('contains')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue(true));
+
+        $this->assertTrue($this->doctrineCacheAdapter->has($id));
+    }
+
+    public function testGetWithValidId()
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('contains')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue(true));
+
+        $this->cache
+            ->expects($this->once())
+            ->method('fetch')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue($data = 'data'));
+
+        $this->assertSame($data, $this->doctrineCacheAdapter->get($id));
+    }
+
+    public function testGetWithInvalidId()
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('contains')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue(false));
+
+        $this->cache
+            ->expects($this->never())
+            ->method('fetch');
+
+        $this->assertNull($this->doctrineCacheAdapter->get($id));
+    }
+
+    public function testSet()
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('save')
+            ->with(
+                $this->identicalTo($id = 'id'),
+                $this->identicalTo($data = 'data'),
+                $this->identicalTo($lifeTime = 123)
+            )
+            ->will($this->returnValue(true));
+
+        $this->assertTrue($this->doctrineCacheAdapter->set($id, $data, $lifeTime));
+    }
+
+    public function testRemove()
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('delete')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue(true));
+
+        $this->assertTrue($this->doctrineCacheAdapter->remove($id));
+    }
+
+    /**
+     * Creates a cache mock.
+     *
+     * @return \Doctrine\Common\Cache\Cache|\PHPUnit_Framework_MockObject_MockObject The cache mock.
+     */
+    private function createCacheMock()
+    {
+        return $this->getMock('Doctrine\Common\Cache\Cache');
+    }
+}

--- a/tests/Event/Cache/Adapter/StashCacheAdapterTest.php
+++ b/tests/Event/Cache/Adapter/StashCacheAdapterTest.php
@@ -1,0 +1,145 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\Cache\Adapter;
+
+use Ivory\HttpAdapter\Event\Cache\Adapter\StashCacheAdapter;
+
+/**
+ * Stash cache adapter test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class StashCacheAdapterTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Ivory\HttpAdapter\Event\Cache\Adapter\StashCacheAdapter */
+    private $stashCacheAdapter;
+
+    /** @var \Stash\Pool|\PHPUnit_Framework_MockObject_MockObject */
+    private $pool;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->pool = $this->createPoolMock();
+        $this->stashCacheAdapter = new StashCacheAdapter($this->pool);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->pool);
+        unset($this->stashCacheAdapter);
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertInstanceOf(
+            'Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface',
+            $this->stashCacheAdapter
+        );
+    }
+
+    public function testHas()
+    {
+        $this->pool
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue($item = $this->createItemMock()));
+
+        $item
+            ->expects($this->once())
+            ->method('isMiss')
+            ->will($this->returnValue(false));
+
+        $this->assertTrue($this->stashCacheAdapter->has($id));
+    }
+
+    public function testGet()
+    {
+        $this->pool
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue($item = $this->createItemMock()));
+
+        $item
+            ->expects($this->once())
+            ->method('get')
+            ->will($this->returnValue($data = 'data'));
+
+        $this->assertSame($data, $this->stashCacheAdapter->get($id));
+    }
+
+    public function testSet()
+    {
+        $this->pool
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue($item = $this->createItemMock()));
+
+        $item
+            ->expects($this->once())
+            ->method('set')
+            ->with($this->identicalTo($data = 'data'), $this->identicalTo($lifeTime = 123))
+            ->will($this->returnValue(true));
+
+        $this->pool
+            ->expects($this->once())
+            ->method('flush');
+
+        $this->assertTrue($this->stashCacheAdapter->set($id, $data, $lifeTime));
+    }
+
+    public function testRemove()
+    {
+        $this->pool
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->identicalTo($id = 'id'))
+            ->will($this->returnValue($item = $this->createItemMock()));
+
+        $item
+            ->expects($this->once())
+            ->method('clear')
+            ->will($this->returnValue(true));
+
+        $this->pool
+            ->expects($this->once())
+            ->method('flush');
+
+        $this->assertTrue($this->stashCacheAdapter->remove($id));
+    }
+
+    /**
+     * Creates a pool mock.
+     *
+     * @return \Stash\Pool|\PHPUnit_Framework_MockObject_MockObject The pool mock.
+     */
+    private function createPoolMock()
+    {
+        return $this->getMock('Stash\Pool');
+    }
+
+    /**
+     * @return \Stash\Item|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createItemMock()
+    {
+        return $this->getMock('Stash\Item');
+    }
+}

--- a/tests/Event/Cache/CacheTest.php
+++ b/tests/Event/Cache/CacheTest.php
@@ -1,0 +1,416 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\Cache\Adapter;
+
+use Ivory\HttpAdapter\Event\Cache\Cache;
+use Ivory\HttpAdapter\Message\RequestInterface;
+
+/**
+ * Cache test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class CacheTest extends \PHPUnit_Framework_TestCase
+{
+    /** @var \Ivory\HttpAdapter\Event\Cache\Cache */
+    private $cache;
+
+    /** @var \Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $adapter;
+
+    /** @var \Ivory\HttpAdapter\Event\Formatter\FormatterInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $formatter;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->adapter = $this->createCacheAdapterMock();
+        $this->formatter = $this->createFormatterMock();
+        $this->cache = new Cache($this->adapter, $this->formatter);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->formatter);
+        unset($this->adapter);
+        unset($this->cache);
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Event\Cache\CacheInterface', $this->cache);
+        $this->assertSame($this->adapter, $this->cache->getAdapter());
+        $this->assertSame($this->formatter, $this->cache->getFormatter());
+        $this->assertNull($this->cache->getLifeTime());
+        $this->assertTrue($this->cache->cacheException());
+    }
+
+    public function testInitialState()
+    {
+        $this->cache = new Cache($this->adapter, $this->formatter, $lifeTime = 100, false);
+
+        $this->assertSame($lifeTime, $this->cache->getLifeTime());
+        $this->assertFalse($this->cache->cacheException());
+    }
+
+    public function testSetAdapter()
+    {
+        $this->cache->setAdapter($adapter = $this->createCacheAdapterMock());
+
+        $this->assertSame($adapter, $this->cache->getAdapter());
+    }
+
+    public function testSetFormatter()
+    {
+        $this->cache->setFormatter($formatter = $this->createFormatterMock());
+
+        $this->assertSame($formatter, $this->cache->getFormatter());
+    }
+
+    public function testSetCacheException()
+    {
+        $this->cache->cacheException(false);
+
+        $this->assertFalse($this->cache->cacheException());
+    }
+
+    public function testGetResponseWithCachedResponse()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = 'cd026c3d697e7e0ba79cdc3d0b054a4c65b84f2f'))
+            ->will($this->returnValue(true));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($id))
+            ->will($this->returnValue(json_encode([
+                'protocol_version' => $protocolVersion = RequestInterface::PROTOCOL_VERSION_1_1,
+                'status_code'      => $statusCode = 200,
+                'headers'          => $headers = ['foo' => 'bar'],
+                'body'             => $body = 'body',
+                'parameters'       => $parameters = ['baz' => 'bat'],
+            ])));
+
+        $messageFactory = $this->createMessageFactoryMock();
+
+        $messageFactory
+            ->expects($this->once())
+            ->method('createResponse')
+            ->with(
+                $this->identicalTo($statusCode),
+                $this->identicalTo($protocolVersion),
+                $this->identicalTo($headers),
+                $this->identicalTo($body),
+                $this->identicalTo($parameters)
+            )
+            ->will($this->returnValue($response = $this->createResponseMock()));
+
+        $response
+            ->expects($this->once())
+            ->method('withParameter')
+            ->with($this->identicalTo('request'), $this->identicalTo($request))
+            ->will($this->returnValue($finalResponse = $this->createResponseMock()));
+
+        $this->assertSame($finalResponse, $this->cache->getResponse($request, $messageFactory));
+    }
+
+    public function testGetResponseWithoutCachedResponse()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = 'cd026c3d697e7e0ba79cdc3d0b054a4c65b84f2f'))
+            ->will($this->returnValue(false));
+
+        $this->adapter
+            ->expects($this->never())
+            ->method('get');
+
+        $this->assertNull($this->cache->getResponse($request, $this->createMessageFactoryMock()));
+    }
+
+    public function testGetExceptionWithCachedException()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = '92bddc469be2d3193975f36b54c1c3ae470b11fd'))
+            ->will($this->returnValue(true));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->identicalTo($id))
+            ->will($this->returnValue(json_encode(['message' => $message = 'message'])));
+
+        $exception = $this->cache->getException($request, $this->createMessageFactoryMock());
+
+        $this->assertSame($message, $exception->getMessage());
+        $this->assertSame($request, $exception->getRequest());
+        $this->assertNull($exception->getResponse());
+    }
+
+    public function testGetExceptionWithoutCachedException()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = '92bddc469be2d3193975f36b54c1c3ae470b11fd'))
+            ->will($this->returnValue(false));
+
+        $this->adapter
+            ->expects($this->never())
+            ->method('get');
+
+        $this->assertNull($this->cache->getException($request, $this->createMessageFactoryMock()));
+    }
+
+    public function testGetExceptionWithCachedExceptionButDisabled()
+    {
+        $this->cache->cacheException(false);
+
+        $this->assertNull($this->cache->getException(
+            $this->createInternalRequestMock(),
+            $this->createMessageFactoryMock()
+        ));
+    }
+
+    public function testSaveResponse()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatResponse')
+            ->with($this->identicalTo($response = $this->createResponseMock()))
+            ->will($this->returnValue($formattedResponse = ['response']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = 'cd026c3d697e7e0ba79cdc3d0b054a4c65b84f2f'))
+            ->will($this->returnValue(false));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->identicalTo($id),
+                $this->identicalTo(json_encode($formattedResponse, true)),
+                $this->identicalTo($lifeTime = 100)
+            );
+
+        $this->cache->setLifeTime($lifeTime);
+        $this->cache->saveResponse($response, $request);
+    }
+
+    public function testSaveResponseWithAlreadySaved()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = 'cd026c3d697e7e0ba79cdc3d0b054a4c65b84f2f'))
+            ->will($this->returnValue(true));
+
+        $this->adapter
+            ->expects($this->never())
+            ->method('set');
+
+        $this->cache->saveResponse($this->createResponseMock(), $request);
+    }
+
+    public function testSaveException()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatException')
+            ->with($this->identicalTo($exception = $this->createExceptionMock()))
+            ->will($this->returnValue($formattedException = ['exception']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = '92bddc469be2d3193975f36b54c1c3ae470b11fd'))
+            ->will($this->returnValue(false));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('set')
+            ->with(
+                $this->identicalTo($id),
+                $this->identicalTo(json_encode($formattedException, true)),
+                $this->identicalTo($lifeTime = 100)
+            );
+
+        $this->cache->setLifeTime($lifeTime);
+        $this->cache->saveException($exception, $request);
+    }
+
+    public function testSaveExceptionDisabled()
+    {
+        $this->adapter
+            ->expects($this->never())
+            ->method('has');
+
+        $this->adapter
+            ->expects($this->never())
+            ->method('set');
+
+        $this->cache->cacheException(false);
+        $this->cache->saveException($this->createExceptionMock(), $this->createInternalRequestMock());
+    }
+
+    public function testSaveExceptionAlreadySaved()
+    {
+        $request = $this->createInternalRequestMock();
+
+        $this->formatter
+            ->expects($this->once())
+            ->method('formatRequest')
+            ->with($this->identicalTo($request))
+            ->will($this->returnValue(['request']));
+
+        $this->adapter
+            ->expects($this->once())
+            ->method('has')
+            ->with($this->identicalTo($id = '92bddc469be2d3193975f36b54c1c3ae470b11fd'))
+            ->will($this->returnValue(true));
+
+        $this->adapter
+            ->expects($this->never())
+            ->method('set');
+
+        $this->cache->saveException($this->createExceptionMock(), $request);
+    }
+
+    /**
+     * Creates a cache adapter mock.
+     *
+     * @return \Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface|\PHPUnit_Framework_MockObject_MockObject The cache adapter mock.
+     */
+    private function createCacheAdapterMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Event\Cache\Adapter\CacheAdapterInterface');
+    }
+
+    /**
+     * Creates a formatter mock.
+     *
+     * @return \Ivory\HttpAdapter\Event\Formatter\FormatterInterface|\PHPUnit_Framework_MockObject_MockObject The formatter mock.
+     */
+    private function createFormatterMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Event\Formatter\FormatterInterface');
+    }
+
+    /**
+     * Creates a message factory mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\MessageFactoryInterface|\PHPUnit_Framework_MockObject_MockObject The message factory mock.
+     */
+    private function createMessageFactoryMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\MessageFactoryInterface');
+    }
+
+    /**
+     * Creates an internal request mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject The internal request mock.
+     */
+    private function createInternalRequestMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\InternalRequestInterface');
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response.
+     */
+    private function createResponseMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+    }
+
+    /**
+     * Creates an exception mock.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The exception mock.
+     */
+    private function createExceptionMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterException');
+    }
+}

--- a/tests/Event/MultiRequestCreatedEventTest.php
+++ b/tests/Event/MultiRequestCreatedEventTest.php
@@ -48,6 +48,8 @@ class MultiRequestCreatedEventTest extends AbstractEventTest
         parent::testDefaultState();
 
         $this->assertRequests($this->requests);
+        $this->assertNoResponses();
+        $this->assertNoExceptions();
     }
 
     public function testInitialState()
@@ -103,6 +105,98 @@ class MultiRequestCreatedEventTest extends AbstractEventTest
         $this->assertNoRequest($request);
     }
 
+    public function testSetResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+
+        $this->assertResponses($responses);
+    }
+
+    public function testAddResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+        $this->event->addResponses($newResponses = array($this->createResponseMock()));
+
+        $this->assertResponses(array_merge($responses, $newResponses));
+    }
+
+    public function testRemoveResponses()
+    {
+        $this->event->setResponses($responses = array($this->createResponseMock()));
+        $this->event->removeResponses($responses);
+
+        $this->assertNoResponses();
+    }
+
+    public function testClearResponses()
+    {
+        $this->event->setResponses(array($this->createResponseMock()));
+        $this->event->clearResponses();
+
+        $this->assertNoResponses();
+    }
+
+    public function testAddResponse()
+    {
+        $this->event->addResponse($response = $this->createResponseMock());
+
+        $this->assertResponse($response);
+    }
+
+    public function testRemoveResponse()
+    {
+        $this->event->addResponse($response = $this->createResponseMock());
+        $this->event->removeResponse($response);
+
+        $this->assertNoResponse($response);
+    }
+
+    public function testSetExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+
+        $this->assertExceptions($exceptions);
+    }
+
+    public function testAddExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->event->addExceptions($newExceptions = array($this->createExceptionMock()));
+
+        $this->assertExceptions(array_merge($exceptions, $newExceptions));
+    }
+
+    public function testRemoveExceptions()
+    {
+        $this->event->setExceptions($exceptions = array($this->createExceptionMock()));
+        $this->event->removeExceptions($exceptions);
+
+        $this->assertNoExceptions();
+    }
+
+    public function testClearExceptions()
+    {
+        $this->event->setExceptions(array($this->createExceptionMock()));
+        $this->event->clearExceptions();
+
+        $this->assertNoExceptions();
+    }
+
+    public function testAddException()
+    {
+        $this->event->addException($exception = $this->createExceptionMock());
+
+        $this->assertException($exception);
+    }
+
+    public function testRemoveException()
+    {
+        $this->event->addException($exception = $this->createExceptionMock());
+        $this->event->removeException($exception);
+
+        $this->assertNoException($exception);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -119,6 +213,26 @@ class MultiRequestCreatedEventTest extends AbstractEventTest
     private function createRequestMock()
     {
         return $this->getMock('Ivory\HttpAdapter\Message\InternalRequestInterface');
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject The response mock.
+     */
+    private function createResponseMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+    }
+
+    /**
+     * Creates an exception mock.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException|\PHPUnit_Framework_MockObject_MockObject The exception mock.
+     */
+    private function createExceptionMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterException');
     }
 
     /**
@@ -165,5 +279,96 @@ class MultiRequestCreatedEventTest extends AbstractEventTest
     {
         $this->assertInstanceOf('Ivory\HttpAdapter\Message\RequestInterface', $request);
         $this->assertFalse($this->event->hasRequest($request));
+    }
+
+    /**
+     * Asserts there are the responses.
+     *
+     * @param array $responses The responses.
+     */
+    private function assertResponses(array $responses)
+    {
+        $this->assertTrue($this->event->hasResponses());
+        $this->assertSame($responses, $this->event->getResponses());
+
+        foreach ($responses as $response) {
+            $this->assertResponse($response);
+        }
+    }
+
+    /**
+     * Asserts there are no responses.
+     */
+    private function assertNoResponses()
+    {
+        $this->assertFalse($this->event->hasResponses());
+        $this->assertEmpty($this->event->getResponses());
+    }
+
+    /**
+     * Asserts there is a response.
+     *
+     * @param \Ivory\HttpAdapter\Message\ResponseInterface $response The response.
+     */
+    private function assertResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertTrue($this->event->hasResponse($response));
+    }
+
+    /**
+     * Asserts there is no response.
+     *
+     * @param string $response The response.
+     */
+    private function assertNoResponse($response)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\Message\ResponseInterface', $response);
+        $this->assertFalse($this->event->hasResponse($response));
+    }
+
+    /**
+     * Asserts there are the exceptions.
+     *
+     * @param array $exceptions The exceptions.
+     */
+    private function assertExceptions(array $exceptions)
+    {
+        $this->assertTrue($this->event->hasExceptions());
+        $this->assertSame($exceptions, $this->event->getExceptions());
+
+        foreach ($exceptions as $exception) {
+            $this->assertException($exception);
+        }
+    }
+
+    /**
+     * Asserts there are no exceptions.
+     */
+    private function assertNoExceptions()
+    {
+        $this->assertFalse($this->event->hasExceptions());
+        $this->assertEmpty($this->event->getExceptions());
+    }
+
+    /**
+     * Asserts there is an exception.
+     *
+     * @param \Ivory\HttpAdapter\HttpAdapterException $exception The exception.
+     */
+    private function assertException($exception)
+    {
+        $this->assertInstanceOf('Ivory\HttpAdapter\HttpAdapterException', $exception);
+        $this->assertTrue($this->event->hasException($exception));
+    }
+
+    /**
+     * Asserts there is no exception.
+     *
+     * @param string $exception The exception.
+     */
+    private function assertNoException($exception)
+    {
+        $this->assertFalse($this->event->hasException($exception));
     }
 }

--- a/tests/Event/RequestCreatedEventTest.php
+++ b/tests/Event/RequestCreatedEventTest.php
@@ -21,7 +21,7 @@ use Ivory\HttpAdapter\Event\RequestCreatedEvent;
 class RequestCreatedEventTest extends AbstractEventTest
 {
     /** @var \Ivory\HttpAdapter\Message\InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject */
-    protected $request;
+    private $request;
 
     /**
      * {@inheritdoc}
@@ -48,6 +48,10 @@ class RequestCreatedEventTest extends AbstractEventTest
         parent::setUp();
 
         $this->assertSame($this->request, $this->event->getRequest());
+        $this->assertFalse($this->event->hasResponse());
+        $this->assertNull($this->event->getResponse());
+        $this->assertFalse($this->event->hasException());
+        $this->assertNull($this->event->getException());
     }
 
     public function testSetRequest()
@@ -55,6 +59,22 @@ class RequestCreatedEventTest extends AbstractEventTest
         $this->event->setRequest($request = $this->createRequestMock());
 
         $this->assertSame($request, $this->event->getRequest());
+    }
+
+    public function testSetResponse()
+    {
+        $this->event->setResponse($response = $this->createResponseMock());
+
+        $this->assertTrue($this->event->hasResponse());
+        $this->assertSame($response, $this->event->getResponse());
+    }
+
+    public function testSetException()
+    {
+        $this->event->setException($exception = $this->createExceptionMock());
+
+        $this->assertTrue($this->event->hasException());
+        $this->assertSame($exception, $this->event->getException());
     }
 
     /**
@@ -73,5 +93,25 @@ class RequestCreatedEventTest extends AbstractEventTest
     private function createRequestMock()
     {
         return $this->getMock('Ivory\HttpAdapter\Message\InternalRequestInterface');
+    }
+
+    /**
+     * Creates a response mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\ResponseInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createResponseMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\ResponseInterface');
+    }
+
+    /**
+     * Creates an exception mock.
+     *
+     * @return \Ivory\HttpAdapter\HttpAdapterException|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createExceptionMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\HttpAdapterException');
     }
 }

--- a/tests/Event/RequestSentEventTest.php
+++ b/tests/Event/RequestSentEventTest.php
@@ -18,8 +18,11 @@ use Ivory\HttpAdapter\Event\RequestSentEvent;
  *
  * @author GeLo <geloen.eric@gmail.com>
  */
-class RequestSentEventTest extends RequestCreatedEventTest
+class RequestSentEventTest extends AbstractEventTest
 {
+    /** @var \Ivory\HttpAdapter\Message\InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $request;
+
     /** @var \Ivory\HttpAdapter\Message\ResponseInterface[\PHPUnit_Framework_MockObject_MockObject */
     private $response;
 
@@ -28,6 +31,7 @@ class RequestSentEventTest extends RequestCreatedEventTest
      */
     protected function setUp()
     {
+        $this->request = $this->createRequestMock();
         $this->response = $this->createResponseMock();
 
         parent::setUp();
@@ -38,6 +42,7 @@ class RequestSentEventTest extends RequestCreatedEventTest
      */
     protected function tearDown()
     {
+        unset($this->request);
         unset($this->response);
 
         parent::tearDown();
@@ -45,11 +50,17 @@ class RequestSentEventTest extends RequestCreatedEventTest
 
     public function testDefaultState()
     {
-        parent::testDefaultState();
-
+        $this->assertSame($this->request, $this->event->getRequest());
         $this->assertSame($this->response, $this->event->getResponse());
         $this->assertFalse($this->event->hasException());
         $this->assertNull($this->event->getException());
+    }
+
+    public function testSetRequest()
+    {
+        $this->event->setRequest($request = $this->createRequestMock());
+
+        $this->assertSame($request, $this->event->getRequest());
     }
 
     public function testSetResponse()
@@ -73,6 +84,16 @@ class RequestSentEventTest extends RequestCreatedEventTest
     protected function createEvent()
     {
         return new RequestSentEvent($this->httpAdapter, $this->request, $this->response);
+    }
+
+    /**
+     * Creates a request mock.
+     *
+     * @return \Ivory\HttpAdapter\Message\InternalRequestInterface|\PHPUnit_Framework_MockObject_MockObject The request mock.
+     */
+    private function createRequestMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Message\InternalRequestInterface');
     }
 
     /**

--- a/tests/Event/Subscriber/CacheSubscriberTest.php
+++ b/tests/Event/Subscriber/CacheSubscriberTest.php
@@ -1,0 +1,340 @@
+<?php
+
+/*
+ * This file is part of the Ivory Http Adapter package.
+ *
+ * (c) Eric GELOEN <geloen.eric@gmail.com>
+ *
+ * For the full copyright and license information, please read the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Ivory\Tests\HttpAdapter\Event\Subscriber;
+
+use Ivory\HttpAdapter\Event\Events;
+use Ivory\HttpAdapter\Event\Subscriber\CacheSubscriber;
+
+/**
+ * Cache subscriber test.
+ *
+ * @author GeLo <geloen.eric@gmail.com>
+ */
+class CacheSubscriberTest extends AbstractSubscriberTest
+{
+    /** @var \Ivory\HttpAdapter\Event\Subscriber\CacheSubscriber */
+    private $cacheSubscriber;
+
+    /** @var \Ivory\HttpAdapter\Event\Cache\CacheInterface|\PHPUnit_Framework_MockObject_MockObject */
+    private $cache;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp()
+    {
+        $this->cache = $this->createCacheMock();
+        $this->cacheSubscriber = new CacheSubscriber($this->cache);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown()
+    {
+        unset($this->cache);
+        unset($this->cacheSubscriber);
+    }
+
+    public function testDefaultState()
+    {
+        $this->assertSame($this->cache, $this->cacheSubscriber->getCache());
+    }
+
+    public function testSubscribedEvents()
+    {
+        $events = CacheSubscriber::getSubscribedEvents();
+
+        $this->assertArrayHasKey(Events::REQUEST_CREATED, $events);
+        $this->assertSame(['onRequestCreated', -100], $events[Events::REQUEST_CREATED]);
+
+        $this->assertArrayHasKey(Events::REQUEST_SENT, $events);
+        $this->assertSame(['onRequestSent', -100], $events[Events::REQUEST_SENT]);
+
+        $this->assertArrayHasKey(Events::REQUEST_ERRORED, $events);
+        $this->assertSame(['onRequestErrored', -100], $events[Events::REQUEST_ERRORED]);
+
+        $this->assertArrayHasKey(Events::MULTI_REQUEST_CREATED, $events);
+        $this->assertSame(['onMultiRequestCreated', -100], $events[Events::MULTI_REQUEST_CREATED]);
+
+        $this->assertArrayHasKey(Events::MULTI_REQUEST_SENT, $events);
+        $this->assertSame(['onMultiRequestSent', -100], $events[Events::MULTI_REQUEST_SENT]);
+
+        $this->assertArrayHasKey(Events::MULTI_REQUEST_ERRORED, $events);
+        $this->assertSame(['onMultiRequestErrored', -100], $events[Events::MULTI_REQUEST_ERRORED]);
+    }
+
+    public function testRequestCreatedEvent()
+    {
+        $messageFactory = $this->createMessageFactoryMock();
+        $configuration = $this->createConfigurationMock($messageFactory);
+        $httpAdapter = $this->createHttpAdapterMock($configuration);
+        $request = $this->createRequestMock();
+
+        $this->cache
+            ->expects($this->once())
+            ->method('getResponse')
+            ->with(
+                $this->identicalTo($request),
+                $this->identicalTo($messageFactory)
+            );
+
+        $this->cache
+            ->expects($this->once())
+            ->method('getException')
+            ->with(
+                $this->identicalTo($request),
+                $this->identicalTo($messageFactory)
+            );
+
+        $this->cacheSubscriber->onRequestCreated($event = $this->createRequestCreatedEvent($httpAdapter, $request));
+
+        $this->assertNull($event->getResponse());
+        $this->assertNull($event->getException());
+    }
+
+    public function testRequestCreatedEventWithCachedResponse()
+    {
+        $messageFactory = $this->createMessageFactoryMock();
+        $configuration = $this->createConfigurationMock($messageFactory);
+        $httpAdapter = $this->createHttpAdapterMock($configuration);
+        $request = $this->createRequestMock();
+
+        $this->cache
+            ->expects($this->once())
+            ->method('getResponse')
+            ->with(
+                $this->identicalTo($request),
+                $this->identicalTo($messageFactory)
+            )
+            ->will($this->returnValue($response = $this->createResponseMock()));
+
+        $this->cacheSubscriber->onRequestCreated($event = $this->createRequestCreatedEvent($httpAdapter, $request));
+
+        $this->assertSame($response, $event->getResponse());
+        $this->assertNull($event->getException());
+    }
+
+    public function testRequestCreatedEventWithCachedException()
+    {
+        $messageFactory = $this->createMessageFactoryMock();
+        $configuration = $this->createConfigurationMock($messageFactory);
+        $httpAdapter = $this->createHttpAdapterMock($configuration);
+        $request = $this->createRequestMock();
+
+        $this->cache
+            ->expects($this->once())
+            ->method('getResponse')
+            ->with(
+                $this->identicalTo($request),
+                $this->identicalTo($messageFactory)
+            );
+
+        $this->cache
+            ->expects($this->once())
+            ->method('getException')
+            ->with(
+                $this->identicalTo($request),
+                $this->identicalTo($messageFactory)
+            )
+            ->will($this->returnValue($exception = $this->createExceptionMock()));
+
+        $this->cacheSubscriber->onRequestCreated($event = $this->createRequestCreatedEvent($httpAdapter, $request));
+
+        $this->assertNull($event->getResponse());
+        $this->assertSame($exception, $event->getException());
+    }
+
+    public function testRequestSent()
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('saveResponse')
+            ->with(
+                $this->identicalTo($response = $this->createResponseMock()),
+                $this->identicalTo($request = $this->createRequestMock())
+            );
+
+        $this->cacheSubscriber->onRequestSent($event = $this->createRequestSentEvent(null, $request, $response));
+    }
+
+    public function testRequestErrored()
+    {
+        $this->cache
+            ->expects($this->once())
+            ->method('saveException')
+            ->with(
+                $this->identicalTo($exception = $this->createExceptionMock($request = $this->createRequestMock())),
+                $this->identicalTo($request)
+            );
+
+        $this->cacheSubscriber->onRequestErrored($event = $this->createRequestErroredEvent(null, $exception));
+    }
+
+    public function testMultiRequestCreatedEvent()
+    {
+        $messageFactory = $this->createMessageFactoryMock();
+        $configuration = $this->createConfigurationMock($messageFactory);
+        $httpAdapter = $this->createHttpAdapterMock($configuration);
+        $requests = [$request1 = $this->createRequestMock(), $request2 = $this->createRequestMock()];
+
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('getResponse')
+            ->withConsecutive(
+                [$request1, $messageFactory],
+                [$request2, $messageFactory]
+            );
+
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('getException')
+            ->withConsecutive(
+                [$request1, $messageFactory],
+                [$request2, $messageFactory]
+            );
+
+        $this->cacheSubscriber->onMultiRequestCreated(
+            $event = $this->createMultiRequestCreatedEvent($httpAdapter, $requests)
+        );
+
+        $this->assertSame($requests, $event->getRequests());
+        $this->assertEmpty($event->getResponses());
+        $this->assertEmpty($event->getExceptions());
+    }
+
+    public function testMultiRequestCreatedEventCachedResponses()
+    {
+        $messageFactory = $this->createMessageFactoryMock();
+        $configuration = $this->createConfigurationMock($messageFactory);
+        $httpAdapter = $this->createHttpAdapterMock($configuration);
+        $requests = [$request1 = $this->createRequestMock(), $request2 = $this->createRequestMock()];
+
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('getResponse')
+            ->will($this->returnValueMap([
+                [$request1, $messageFactory, $response1 = $this->createResponseMock()],
+                [$request2, $messageFactory, $response2 = $this->createResponseMock()]
+            ]));
+
+        $this->cacheSubscriber->onMultiRequestCreated(
+            $event = $this->createMultiRequestCreatedEvent($httpAdapter, $requests)
+        );
+
+        $this->assertEmpty($event->getRequests());
+        $this->assertSame([$response1, $response2], $event->getResponses());
+        $this->assertEmpty($event->getExceptions());
+    }
+
+    public function testMultiRequestCreatedEventCachedExceptions()
+    {
+        $messageFactory = $this->createMessageFactoryMock();
+        $configuration = $this->createConfigurationMock($messageFactory);
+        $httpAdapter = $this->createHttpAdapterMock($configuration);
+        $requests = [$request1 = $this->createRequestMock(), $request2 = $this->createRequestMock()];
+
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('getResponse')
+            ->withConsecutive(
+                [$request1, $messageFactory],
+                [$request2, $messageFactory]
+            );
+
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('getException')
+            ->will($this->returnValueMap([
+                [$request1, $messageFactory, $exception1 = $this->createExceptionMock($request1)],
+                [$request2, $messageFactory, $exception2 = $this->createExceptionMock($request2)]
+            ]));
+
+        $this->cacheSubscriber->onMultiRequestCreated(
+            $event = $this->createMultiRequestCreatedEvent($httpAdapter, $requests)
+        );
+
+        $this->assertEmpty($event->getRequests());
+        $this->assertEmpty($event->getResponses());
+        $this->assertSame([$exception1, $exception2], $event->getExceptions());
+    }
+
+    public function testMultiRequestSent()
+    {
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('saveResponse')
+            ->withConsecutive(
+                [$response1 = $this->createResponseMock(), $request1 = $this->createRequestMock()],
+                [$response2 = $this->createResponseMock(), $request2 = $this->createRequestMock()]
+            );
+
+        $response1
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with($this->identicalTo('request'))
+            ->will($this->returnValue($request1));
+
+        $response2
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with($this->identicalTo('request'))
+            ->will($this->returnValue($request2));
+
+        $this->cacheSubscriber->onMultiRequestSent($this->createMultiRequestSentEvent(null, [$response1, $response2]));
+    }
+
+    public function testMultiRequestErrored()
+    {
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('saveException')
+            ->withConsecutive(
+                [$exception1 = $this->createExceptionMock($request1 = $this->createRequestMock()), $request1],
+                [$exception2 = $this->createExceptionMock($request2 = $this->createRequestMock()), $request2]
+            );
+
+        $this->cache
+            ->expects($this->exactly(2))
+            ->method('saveResponse')
+            ->withConsecutive(
+                [$response1 = $this->createResponseMock(), $request3 = $this->createRequestMock()],
+                [$response2 = $this->createResponseMock(), $request4 = $this->createRequestMock()]
+            );
+
+        $response1
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with($this->identicalTo('request'))
+            ->will($this->returnValue($request3));
+
+        $response2
+            ->expects($this->once())
+            ->method('getParameter')
+            ->with($this->identicalTo('request'))
+            ->will($this->returnValue($request4));
+
+        $this->cacheSubscriber->onMultiRequestErrored(
+            $this->createMultiRequestErroredEvent(null, [$exception1, $exception2], [$response1, $response2])
+        );
+    }
+
+    /**
+     * Creates a cache mock.
+     *
+     * @return \Ivory\HttpAdapter\Event\Cache\CacheInterface|\PHPUnit_Framework_MockObject_MockObject The cache mock.
+     */
+    private function createCacheMock()
+    {
+        return $this->getMock('Ivory\HttpAdapter\Event\Cache\CacheInterface');
+    }
+}

--- a/tests/Event/Subscriber/RedirectSubscriberTest.php
+++ b/tests/Event/Subscriber/RedirectSubscriberTest.php
@@ -295,18 +295,4 @@ class RedirectSubscriberTest extends AbstractSubscriberTest
 
         return $response;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function createConfigurationMock()
-    {
-        $configuration = parent::createConfigurationMock();
-        $configuration
-            ->expects($this->any())
-            ->method('getMessageFactory')
-            ->will($this->returnValue($this->getMock('Ivory\HttpAdapter\Message\MessageFactoryInterface')));
-
-        return $configuration;
-    }
 }

--- a/tests/Event/Subscriber/StatusCodeSubscriberTest.php
+++ b/tests/Event/Subscriber/StatusCodeSubscriberTest.php
@@ -144,20 +144,6 @@ class StatusCodeSubscriberTest extends AbstractSubscriberTest
     /**
      * {@inheritdoc}
      */
-    protected function createHttpAdapterMock()
-    {
-        $httpAdapter = parent::createHttpAdapterMock();
-        $httpAdapter
-            ->expects($this->any())
-            ->method('getName')
-            ->will($this->returnValue('name'));
-
-        return $httpAdapter;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     protected function createRequestMock()
     {
         $request = parent::createRequestMock();


### PR DESCRIPTION
This PR adds caching support for responses or responses/exceptions through an event subscriber. So, if you want to use it you will need to use the event dispatcher http adapter. Here an example using the doctrine cache adapter but there is also a stash adapter and you can use any cache library by implementing the cache adapter interface.

It is also related to #60 

``` php
use Doctrine\Common\Cache\FilesystemCache;
use Ivory\HttpAdapter\Event\Cache\Adapter\DoctrineCacheAdapter;
use Ivory\HttpAdapter\Event\Cache\Cache;
use Ivory\HttpAdapter\Event\Subscriber\CacheSubscriber;
use Ivory\HttpAdapter\EventDispatcherHttpAdapter;
use Ivory\HttpAdapter\SocketHttpAdapter;
use Symfony\Component\EventDispatcher\EventDispatcher;

$filesystemCache = new FilesystemCache(__DIR__.'/cache');
$doctrineCache = new DoctrineCacheAdapter($filesystemCache);
$cache = new Cache($doctrineCache);
$cacheSubscriber = new CacheSubscriber($cache);

$dispatcher = new EventDispatcher();
$dispatcher->addSubscriber($cacheSubscriber);

$http = new EventDispatcherHttpAdapter(new SocketHttpAdapter(), $dispatcher);
```