### PR TITLE
Fix docblock.

### DIFF
--- a/src/Guzzle6HttpAdapter.php
+++ b/src/Guzzle6HttpAdapter.php
@@ -32,7 +32,7 @@ class Guzzle6HttpAdapter extends AbstractHttpAdapter
     /**
      * Creates a guzzle 6 http adapter.
      *
-     * @param \GuzzleHttp\ClientInterface|null               $client        The guzzle 4 client.
+     * @param \GuzzleHttp\ClientInterface|null               $client        The guzzle 6 client.
      * @param \Ivory\HttpAdapter\ConfigurationInterface|null $configuration The configuration.
      */
     public function __construct(ClientInterface $client = null, ConfigurationInterface $configuration = null)


### PR DESCRIPTION
The docblock for the Guzzle 6 adapter had a parameter description which referenced Guzzle 4. This update fixes the docblock to properly reference Guzzle 6.